### PR TITLE
Prevent editing for "empty list"-placeholder row

### DIFF
--- a/OpenGpxTracker/GPXFilesTableViewController.swift
+++ b/OpenGpxTracker/GPXFilesTableViewController.swift
@@ -77,7 +77,9 @@ class GPXFilesTableViewController: UITableViewController, UINavigationBarDelegat
     }
     
     override func tableView(tableView: UITableView, canEditRowAtIndexPath indexPath: NSIndexPath) -> Bool {
-        return true
+        // Allow editing for all rows except the initial "empty list"-placeholder row.
+        // The string comparison is not optimal, but does the job.
+        return fileList.objectAtIndex(indexPath.row) as! String != kNoFiles
     }
     
     override func tableView(tableView: UITableView,
@@ -133,6 +135,15 @@ class GPXFilesTableViewController: UITableViewController, UINavigationBarDelegat
     }
     func actionSheetCancel(actionSheet: UIActionSheet) {
         print("actionsheet cancel")
+    }
+    
+    //#pragma mark - UITableView delegate methods
+    
+    override func tableView(tableView: UITableView,
+                            shouldHighlightRowAtIndexPath indexPath: NSIndexPath) -> Bool {
+        // Allow editing for all rows except the initial "empty list"-placeholder row.
+        // The string comparison is not optimal, but does the job.
+        return fileList.objectAtIndex(indexPath.row) as! String != kNoFiles
     }
     
     //#pragma mark - UIAlertView delegate methods


### PR DESCRIPTION
Add logic in -tableView:canEditRowAtIndexPath: for swiping and
implement -tableView:shouldHighlightRowAtIndexPath: for tapping.

<img width="432" alt="screen shot 2016-08-20 at 11 09 19" src="https://cloud.githubusercontent.com/assets/439447/17832012/1f452ec0-66c7-11e6-8144-e0afb724046c.png">
