### PR TITLE
Enable iTunes File Sharing

### DIFF
--- a/OpenGpxTracker/Info.plist
+++ b/OpenGpxTracker/Info.plist
@@ -56,5 +56,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIFileSharingEnabled</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Addresses enhancement https://github.com/merlos/iOS-Open-GPX-Tracker/issues/17. It's just one commit, adding Info.plist key to share Documents/ directory, where .gpx files are
stored.

It works out of the box with the app's current file persistency model. Has to be tested on-device (not Simulator).

It's handy because traces can be moved off the device w/o going through email, can be renamed, moved between devices, or quickly deleted.

When the file list controller is open and you make changes in iTunes, they are not picked up immediately, but that trade off seems worth the benefit. When closing the file list and reopening, all changes from iTunes are immediately reflected.