### PR TITLE
Share from Files Table

### DIFF
--- a/OpenGpxTracker.xcodeproj/project.pbxproj
+++ b/OpenGpxTracker.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3C0C3354215327D900C1AF4B /* GPXActivityItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0C3353215327D900C1AF4B /* GPXActivityItemProvider.swift */; };
 		8913CD8C1BDB0A9A009EC729 /* PreferencesTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8913CD8B1BDB0A9A009EC729 /* PreferencesTableViewController.swift */; };
 		8913CD8E1BDB2477009EC729 /* PreferencesTableViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8913CD8D1BDB2477009EC729 /* PreferencesTableViewControllerDelegate.swift */; };
 		893BEC8619C7E62200C77354 /* GPXWaypoint+MKAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 893BEC8519C7E62200C77354 /* GPXWaypoint+MKAnnotation.swift */; };
@@ -59,6 +60,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3C0C3353215327D900C1AF4B /* GPXActivityItemProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPXActivityItemProvider.swift; sourceTree = "<group>"; };
 		44E786790A477838358F948C /* Pods-OpenGpxTracker.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenGpxTracker.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OpenGpxTracker/Pods-OpenGpxTracker.debug.xcconfig"; sourceTree = "<group>"; };
 		8913CD8B1BDB0A9A009EC729 /* PreferencesTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferencesTableViewController.swift; sourceTree = "<group>"; };
 		8913CD8D1BDB2477009EC729 /* PreferencesTableViewControllerDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferencesTableViewControllerDelegate.swift; sourceTree = "<group>"; };
@@ -147,6 +149,7 @@
 				895F04B31A7143CE004BEE8A /* GPXExtentCoordinates.swift */,
 				89F8749A1BBB7362004EF41A /* GPXTrack+length.swift */,
 				89F8749E1BBCB97F004EF41A /* GPXRoot+length.swift */,
+				3C0C3353215327D900C1AF4B /* GPXActivityItemProvider.swift */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -470,6 +473,7 @@
 				899D677219CE8B3600C88A0A /* StopWatch.swift in Sources */,
 				893BEC8619C7E62200C77354 /* GPXWaypoint+MKAnnotation.swift in Sources */,
 				DC4908A31C4A332E009484AE /* MapViewDelegate.swift in Sources */,
+				3C0C3354215327D900C1AF4B /* GPXActivityItemProvider.swift in Sources */,
 				898EED3619C6402900B4B207 /* GPXFilesTableViewController.swift in Sources */,
 				DC4908A11C4A136F009484AE /* TrackerButton.swift in Sources */,
 				89F8749F1BBCB97F004EF41A /* GPXRoot+length.swift in Sources */,

--- a/OpenGpxTracker/CachedTileOverlay.swift
+++ b/OpenGpxTracker/CachedTileOverlay.swift
@@ -26,7 +26,7 @@ class CachedTileOverlay : MKTileOverlay {
     
         //get random subdomain
         let subdomains = "abc"
-        let rand = arc4random_uniform(UInt32(subdomains.characters.count))
+        let rand = arc4random_uniform(UInt32(subdomains.count))
         let randIndex = subdomains.index(subdomains.startIndex, offsetBy: String.IndexDistance(rand));
         urlString = urlString?.replacingOccurrences(of: "{s}", with:String(subdomains[randIndex]))
         //print("CachedTileOverlay:: url() urlString: \(urlString)")
@@ -95,9 +95,7 @@ class CachedTileOverlay : MKTileOverlay {
                     //let data = data
                     //save data in cache
                     cache?.async.setObject(data!, forKey: cacheKey) { error in
-                        if error == nil {
-                            print("ERROR saving in cache: \(error)")
-                        }
+                        print("ERROR saving in cache: \(error)")
                     }
                     DispatchQueue.main.async {
                         result(data, nil)

--- a/OpenGpxTracker/GPXActivityItemProvider.swift
+++ b/OpenGpxTracker/GPXActivityItemProvider.swift
@@ -1,0 +1,35 @@
+//
+//  GPXActivityItemProvider.swift
+//  OpenGpxTracker
+//
+//  Created by Ian Grossberg on 9/19/18.
+//  Copyright © 2018 TransitBox. All rights reserved.
+//
+
+import UIKit
+
+class GPXActivityItemProvider: UIActivityItemProvider {
+    let filename: String
+    let gpxFileData: Data
+    
+    init(filename: String, gpxFileData: Data) {
+        self.filename = filename
+        self.gpxFileData = gpxFileData
+        super.init(placeholderItem: gpxFileData)
+    }
+
+    override var item: Any {
+        return self.gpxFileData
+    }
+    
+    override func activityViewController(_ activityViewController: UIActivityViewController, subjectForActivityType activityType: UIActivityType?) -> String {
+        return self.filename
+    }
+    
+    override func activityViewController(
+        _ activityViewController: UIActivityViewController,
+        dataTypeIdentifierForActivityType activityType: UIActivityType?
+        ) -> String {
+        return "com.topografix.gpx"
+    }
+}

--- a/OpenGpxTracker/Info.plist
+++ b/OpenGpxTracker/Info.plist
@@ -102,5 +102,29 @@
 			</dict>
 		</dict>
 	</array>
+    <key>UTImportedTypeDeclarations</key>
+    <array>
+        <dict>
+            <key>UTTypeIdentifier</key>
+            <string>com.topografix.gpx</string>
+            <key>UTTypeReferenceURL</key>
+            <string>http://www.topografix.com/GPX/1/1</string>
+            <key>UTTypeDescription</key>
+            <string>GPS Exchange Format (GPX)</string>
+            <key>UTTypeConformsTo</key>
+            <array>
+                <string>public.xml</string>
+            </array>
+            <key>UTTypeTagSpecification</key>
+            <dict>
+                <key>public.filename-extension</key>
+                <array>
+                    <string>gpx</string>
+                </array>
+                <key>public.mime-type</key>
+                <string>application/gpx+xml</string>
+            </dict>
+        </dict>
+    </array>
 </dict>
 </plist>

--- a/OpenGpxTracker/MapViewDelegate.swift
+++ b/OpenGpxTracker/MapViewDelegate.swift
@@ -62,10 +62,10 @@ class MapViewDelegate: NSObject, MKMapViewDelegate, UIAlertViewDelegate {
         
         switch button.tag {
         case kDeleteWaypointAccesoryButtonTag:
-            print("[calloutAccesoryControlTapped: DELETE button] deleting waypoint with name \(waypoint.name)")
+            print("[calloutAccesoryControlTapped: DELETE button] deleting waypoint with name \(waypoint.name ?? "''")")
             map.removeWaypoint(waypoint)
         case kEditWaypointAccesoryButtonTag:
-            print("[calloutAccesoryControlTapped: EDIT] editing waypoint with name \(waypoint.name)")
+            print("[calloutAccesoryControlTapped: EDIT] editing waypoint with name \(waypoint.name ?? "''")")
             let alert = UIAlertView(title: "Edit Waypoint",
                 message: "Hint: To change the waypoint location drag and drop the pin",
                 delegate: self, cancelButtonTitle: "Cancel")

--- a/OpenGpxTracker/ViewController.swift
+++ b/OpenGpxTracker/ViewController.swift
@@ -954,7 +954,7 @@ extension ViewController: CLLocationManagerDelegate {
         //updates signal image accuracy
         let newLocation = locations.first!
         print("isUserLocationVisible: \(map.isUserLocationVisible) showUserLocation: \(map.showsUserLocation)")
-        print("didUpdateLocation: received \(newLocation.coordinate) hAcc: \(newLocation.horizontalAccuracy) vAcc: \(newLocation.verticalAccuracy) floor: \(newLocation.floor) map.userTrackingMode: \(map.userTrackingMode.hashValue)")
+        print("didUpdateLocation: received \(newLocation.coordinate) hAcc: \(newLocation.horizontalAccuracy) vAcc: \(newLocation.verticalAccuracy) floor: \(newLocation.floor?.description ?? "''") map.userTrackingMode: \(map.userTrackingMode.hashValue)")
         let hAcc = newLocation.horizontalAccuracy
         signalAccuracyLabel.text = "±\(hAcc)m"
         if hAcc < kSignalAccuracy6 {


### PR DESCRIPTION
Hello! This PR accomplishes #46 in a simple manner, adding a button to the Files Table. One could also go further and wrap all of the actions in the `UIAlertController` in `UIActivity`s and only use the `UIActivityViewController` to save taps.

This PR is one of two options, I've also created a PR (#53) that instead adds a Share button onto the main `ViewController`