### PR TITLE
Fix/duplicated tracks

### DIFF
--- a/OpenGpxTracker-Watch Extension/GPXMapView-watchOS.swift
+++ b/OpenGpxTracker-Watch Extension/GPXMapView-watchOS.swift
@@ -96,10 +96,14 @@ class GPXMapView {
     /// Appends currentSegment to trackSegments and initializes currentSegment to a new one.
     ///
     func startNewTrackSegment() {
-        self.trackSegments.append(self.currentSegment)
-        self.currentSegment = GPXTrackSegment()
-        self.currentSegmentDistance = 0.00
+        if self.currentSegment.trackpoints.count > 0 {
+            self.trackSegments.append(self.currentSegment)
+            self.currentSegment = GPXTrackSegment()
+            self.currentSegmentOverlay = MKPolyline()
+            self.currentSegmentDistance = 0.00
+        }
     }
+    
     
     ///
     /// Clears map.

--- a/OpenGpxTracker-Watch Extension/GPXMapView-watchOS.swift
+++ b/OpenGpxTracker-Watch Extension/GPXMapView-watchOS.swift
@@ -138,7 +138,7 @@ class GPXMapView {
         //add existing tracks
         gpx.add(tracks: self.tracks)
         //add current track
-        gpx.add(tracks: [track])
+        gpx.add(track: track)
         return gpx.gpx()
     }
     

--- a/OpenGpxTracker-Watch Extension/GPXMapView-watchOS.swift
+++ b/OpenGpxTracker-Watch Extension/GPXMapView-watchOS.swift
@@ -99,11 +99,9 @@ class GPXMapView {
         if self.currentSegment.trackpoints.count > 0 {
             self.trackSegments.append(self.currentSegment)
             self.currentSegment = GPXTrackSegment()
-            self.currentSegmentOverlay = MKPolyline()
             self.currentSegmentDistance = 0.00
         }
     }
-    
     
     ///
     /// Clears map.
@@ -143,5 +141,5 @@ class GPXMapView {
         gpx.add(tracks: [track])
         return gpx.gpx()
     }
-
+    
 }

--- a/OpenGpxTracker-Watch Extension/GPXMapView-watchOS.swift
+++ b/OpenGpxTracker-Watch Extension/GPXMapView-watchOS.swift
@@ -133,11 +133,11 @@ class GPXMapView {
         if self.currentSegment.trackpoints.count > 0 {
             track.add(trackSegment: self.currentSegment)
         }
-        self.tracks.append(track)
+        //add existing tracks
         gpx.add(tracks: self.tracks)
+        //add current track
+        gpx.add(tracks: [track])
         return gpx.gpx()
     }
-    
-    
 
 }

--- a/OpenGpxTracker/GPXMapView.swift
+++ b/OpenGpxTracker/GPXMapView.swift
@@ -271,8 +271,10 @@ class GPXMapView: MKMapView {
         if self.currentSegment.trackpoints.count > 0 {
             track.add(trackSegment: self.currentSegment)
         }
-        self.tracks.append(track)
+        //add existing tracks
         gpx.add(tracks: self.tracks)
+        //add current track
+        gpx.add(tracks: [track])
         return gpx.gpx()
     }
    

--- a/OpenGpxTracker/GPXMapView.swift
+++ b/OpenGpxTracker/GPXMapView.swift
@@ -277,7 +277,7 @@ class GPXMapView: MKMapView {
         //add existing tracks
         gpx.add(tracks: self.tracks)
         //add current track
-        gpx.add(tracks: [track])
+        gpx.add(track: track)
         return gpx.gpx()
     }
    

--- a/OpenGpxTracker/GPXMapView.swift
+++ b/OpenGpxTracker/GPXMapView.swift
@@ -216,13 +216,16 @@ class GPXMapView: MKMapView {
     }
     
     ///
-    /// Appends currentSegment to trackSegments and initializes currentSegment to a new one.
+    /// If current segmet has points, it appends currentSegment to trackSegments and
+    /// initializes currentSegment to a new one.
     ///
     func startNewTrackSegment() {
-        self.trackSegments.append(self.currentSegment)
-        self.currentSegment = GPXTrackSegment()
-        self.currentSegmentOverlay = MKPolyline()
-        self.currentSegmentDistance = 0.00
+        if self.currentSegment.trackpoints.count > 0 {
+            self.trackSegments.append(self.currentSegment)
+            self.currentSegment = GPXTrackSegment()
+            self.currentSegmentOverlay = MKPolyline()
+            self.currentSegmentDistance = 0.00
+        }
     }
     
     ///


### PR DESCRIPTION
This commit fixes #75 

@vincentneo I used an new branch to keep master commits clean from tests commits.

Also I noticed that sometimes empty segments were created, i fixed that too.
The issue also affected Apple Watch app. 

While fixing, I notice that GPXMapView-watchOS logic duplicates the logic of GPXMapView, which is acceptable, but I am wondering if there is any simple way to have that logic in one single place. I´ll add an enhancement issue as a reminder for us.
