### PR TITLE
Fix battery consumption in Apple Watch

### DIFF
--- a/OpenGpxTracker-Watch Extension/InterfaceController.swift
+++ b/OpenGpxTracker-Watch Extension/InterfaceController.swift
@@ -194,6 +194,7 @@ class InterfaceController: WKInterfaceController {
     
     
     override func awake(withContext context: Any?) {
+        print("InterfaceController:: awake")
         super.awake(withContext: context)
         
         if gpxTrackingStatus == .notStarted {
@@ -208,21 +209,34 @@ class InterfaceController: WKInterfaceController {
             speedLabel.setText(kUnknownSpeedText)
             signalImageView.setImage(signalImage0)
         }
-        
-        // Configure interface objects here.
     }
+    
     
     override func willActivate() {
         // This method is called when watch view controller is about to be visible to user
+         print("InterfaceController:: willActivate")
         super.willActivate()
         self.setTitle("GPX Tracker")
         
         stopWatch.delegate = self
         
         locationManager.delegate = self
+        checkLocationServicesStatus()
         locationManager.startUpdatingLocation()
         
     }
+    
+    override func didDeactivate() {
+        // This method is called when watch view controller is no longer visible
+        super.didDeactivate()
+        print("InterfaceController:: didDeactivate called")
+        
+        if gpxTrackingStatus != .tracking {
+            print("InterfaceController:: didDeactivate will stopUpdatingLocation")
+            locationManager.stopUpdatingLocation()
+        }
+    }
+    
     
     
     ///
@@ -292,11 +306,7 @@ class InterfaceController: WKInterfaceController {
         self.gpxTrackingStatus = .notStarted
     }
     
-    override func didDeactivate() {
-        // This method is called when watch view controller is no longer visible
-        super.didDeactivate()
-    }
-    
+   
     /// returns a string with the format of current date dd-MMM-yyyy-HHmm' (20-Jun-2018-1133)
     ///
     func defaultFilename() -> String {
@@ -306,35 +316,8 @@ class InterfaceController: WKInterfaceController {
         return dateFormatter.string(from: Date())
     }
     
-    ///
-    /// Called when the application Becomes active (background -> foreground) this function verifies if
-    /// it has permissions to get the location.
-    ///
-    @objc func applicationDidBecomeActive() {
-        print("InterfaceController:: applicationDidBecomeActive wasSentToBackground: \(wasSentToBackground) locationServices: \(CLLocationManager.locationServicesEnabled())")
-        
-        //If the app was never sent to background do nothing
-        if !wasSentToBackground {
-            return
-        }
-        checkLocationServicesStatus()
-        locationManager.startUpdatingLocation()
-    }
-    
-    ///
-    /// Actions to do in case the app entered in background
-    ///
-    /// In current implementation if the app is not tracking it requests the OS to stop
-    /// sharing the location to save battery.
-    ///
-    ///
-    @objc func didEnterBackground() {
-        wasSentToBackground = true // flag the application was sent to background
-        print("InterfaceController:: didEnterBackground")
-        if gpxTrackingStatus != .tracking {
-            locationManager.stopUpdatingLocation()
-        }
-    }
+   
+ 
     
     ///
     /// Actions to do when the app will terminate

--- a/OpenGpxTracker-Watch Extension/InterfaceController.swift
+++ b/OpenGpxTracker-Watch Extension/InterfaceController.swift
@@ -316,17 +316,6 @@ class InterfaceController: WKInterfaceController {
         return dateFormatter.string(from: Date())
     }
     
-   
- 
-    
-    ///
-    /// Actions to do when the app will terminate
-    ///
-    /// In current implementation it removes all the temporary files that may have been created
-    @objc func applicationWillTerminate() {
-        print("viewController:: applicationWillTerminate")
-        GPXFileManager.removeTemporaryFiles()
-    }
     
     ///
     /// Checks the location services status


### PR DESCRIPTION
Closes #77. 

Once the Apple Watch Extension was started, it was requesting the location all the time independently of being tracking or not. 

To fix the issue I just moved the logic of `startUpdatingLocation` and `stopUpdatingLocation` to `didActivate` and `didDeactivate` respectively. 

 `applicationDidBecomeActive()` and `didEnterBackground()` were never called, so were removed.

@vincentneo, does the watch extension create any temporary files? `applicationWillTerminate`  calls `GPXFileManager.removeTemporaryFiles()`, but `applicationWillTerminate` is never run. Shall we remove it or move to another place?

Thanks! 

