### PR TITLE
Auto reload table view when file received

### DIFF
--- a/OpenGpxTracker/AppDelegate.swift
+++ b/OpenGpxTracker/AppDelegate.swift
@@ -52,14 +52,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationDidBecomeActive(_ application: UIApplication) {
         if #available(iOS 9.0, *) {
             if WCSession.isSupported() {
-                print("ViewController:: WCSession is supported")
+                print("AppDelegate:: WCSession is supported")
                 let session = WCSession.default
                 session.delegate = self
                 session.activate()
-                print("ViewController:: WCSession activated")
+                print("AppDelegate:: WCSession activated")
             }
             else {
-                print("ViewController:: WCSession is not supported")
+                print("AppDelegate:: WCSession is not supported")
             }
         }
         // Restart any tasks that were paused (or not yet started) while the application was inactive. 
@@ -182,12 +182,12 @@ extension AppDelegate: WCSessionDelegate {
     
     /// called when `WCSession` goes inactive. Does nothing but display a debug message.
     func sessionDidBecomeInactive(_ session: WCSession) {
-        print("GPXFilesTableViewController:: WCSession has become inactive")
+        print("AppDelegate:: WCSession has become inactive")
     }
     
     /// called when `WCSession` goes inactive. Does nothing but display a debug message
     func sessionDidDeactivate(_ session: WCSession) {
-        print("GPXFilesTableViewController:: WCSession has deactivated")
+        print("AppDelegate:: WCSession has deactivated")
     }
     
     /// called when activation did complete. Does nothing but display a debug message.
@@ -195,11 +195,11 @@ extension AppDelegate: WCSessionDelegate {
     func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
         switch activationState {
         case .activated:
-            print("GPXFilesTableViewController:: activationDidCompleteWithActivationState: session activated")
+            print("AppDelegate:: activationDidCompleteWithActivationState: WCSession activated")
         case .inactive:
-            print("GPXFilesTableViewController:: activationDidCompleteWithActivationState: session inactive")
+            print("AppDelegate:: activationDidCompleteWithActivationState: WCSession inactive")
         case .notActivated:
-            print("GPXFilesTableViewController:: activationDidCompleteWithActivationState: session not activated, error:\(String(describing: error))")
+            print("AppDelegate:: activationDidCompleteWithActivationState: WCSession not activated, error:\(String(describing: error))")
             
         default: break
         }
@@ -214,12 +214,18 @@ extension AppDelegate: WCSessionDelegate {
             GPXFileManager.moveFrom(file.fileURL, fileName: fileName)
             print("ViewController:: Received file from WatchConnectivity Session")
         }
-        NotificationCenter.default.post(name: .didReceiveFileFromAppleWatch, object: nil, userInfo: ["fileName": fileName])
+        
+        // posts notification that file is received from apple watch
+        NotificationCenter.default.post(name: .didReceiveFileFromAppleWatch, object: nil, userInfo: ["fileName": fileName ?? ""])
     }
 }
 
+/// Notifications for file receival from external source.
 extension Notification.Name {
+    
     /// Use when a file is received from external source.
     static let didReceiveFileFromURL = Notification.Name("didReceiveFileFromURL")
+    
+    /// Use when a file is received from Apple Watch.
     static let didReceiveFileFromAppleWatch = Notification.Name("didReceiveFileFromAppleWatch")
 }

--- a/OpenGpxTracker/AppDelegate.swift
+++ b/OpenGpxTracker/AppDelegate.swift
@@ -71,6 +71,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             print("Ooops! Something went wrong: \(error)")
         }
         
+        NotificationCenter.default.post(name: .didReceiveFileFromURL, object: nil)
         return true
     }
     
@@ -149,4 +150,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         }
     }
+}
+
+extension Notification.Name {
+    static let didReceiveFileFromURL = Notification.Name("didReceiveFileFromURL")
 }

--- a/OpenGpxTracker/AppDelegate.swift
+++ b/OpenGpxTracker/AppDelegate.swift
@@ -71,7 +71,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             print("Ooops! Something went wrong: \(error)")
         }
         
+        // post a notification when a file is received through this method.
         NotificationCenter.default.post(name: .didReceiveFileFromURL, object: nil)
+        
         return true
     }
     
@@ -153,5 +155,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 }
 
 extension Notification.Name {
+    /// Use when a file is received from external source.
     static let didReceiveFileFromURL = Notification.Name("didReceiveFileFromURL")
 }

--- a/OpenGpxTracker/GPXFilesTableViewController.swift
+++ b/OpenGpxTracker/GPXFilesTableViewController.swift
@@ -56,6 +56,7 @@ class GPXFilesTableViewController: UITableViewController, UINavigationBarDelegat
         
         self.title = "Your GPX Files"
         
+        // add notification observer for reloading table when file is added.
         addNotificationObservers()
         
         // Button to return to the map
@@ -72,6 +73,7 @@ class GPXFilesTableViewController: UITableViewController, UINavigationBarDelegat
         }
     }
     
+    /// Removes notfication observers
     deinit {
         removeNotificationObservers()
     }
@@ -263,7 +265,11 @@ class GPXFilesTableViewController: UITableViewController, UINavigationBarDelegat
     
 }
 
+///
+/// Handles reloading of table view when file is added while user is still in current view.
+///
 extension GPXFilesTableViewController {
+    
     ///
     /// Asks the system to notify the app on some events
     ///
@@ -285,6 +291,11 @@ extension GPXFilesTableViewController {
         NotificationCenter.default.removeObserver(self)
     }
     
+    ///
+    /// Reload Table View data
+    ///
+    /// For reloading table when a new file is added while user is in `GPXFileTableViewController`
+    ///
     @objc func reloadTableData() {
         let list: [GPXFileInfo] = GPXFileManager.fileList
         if self.fileList.count < list.count && list.count != 0 {

--- a/OpenGpxTracker/GPXFilesTableViewController.swift
+++ b/OpenGpxTracker/GPXFilesTableViewController.swift
@@ -298,12 +298,15 @@ extension GPXFilesTableViewController {
     /// For reloading table when a new file is added while user is in `GPXFileTableViewController`
     ///
     @objc func reloadTableData() {
+        print("TableViewController: reloadTableData")
         let list: [GPXFileInfo] = GPXFileManager.fileList
         if self.fileList.count < list.count && list.count != 0 {
             self.fileList.removeAllObjects()
             self.fileList.addObjects(from: list)
             self.gpxFilesFound = true
-            self.tableView.reloadData()
+            DispatchQueue.main.async {
+                self.tableView.reloadData()
+            }
         }
     }
     

--- a/OpenGpxTracker/GPXFilesTableViewController.swift
+++ b/OpenGpxTracker/GPXFilesTableViewController.swift
@@ -282,6 +282,7 @@ extension GPXFilesTableViewController {
         
         notificationCenter.addObserver(self, selector: #selector(reloadTableData),
                                        name: .didReceiveFileFromURL, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(reloadTableData), name: .didReceiveFileFromAppleWatch, object: nil)
     }
     
     ///

--- a/OpenGpxTracker/GPXFilesTableViewController.swift
+++ b/OpenGpxTracker/GPXFilesTableViewController.swift
@@ -56,6 +56,8 @@ class GPXFilesTableViewController: UITableViewController, UINavigationBarDelegat
         
         self.title = "Your GPX Files"
         
+        addNotificationObservers()
+        
         // Button to return to the map
         let shareItem = UIBarButtonItem(title: "Done", style: UIBarButtonItem.Style.plain, target: self, action: #selector(GPXFilesTableViewController.closeGPXFilesTableViewController))
         
@@ -70,6 +72,9 @@ class GPXFilesTableViewController: UITableViewController, UINavigationBarDelegat
         }
     }
     
+    deinit {
+        removeNotificationObservers()
+    }
     
     /// Closes this view controller.
     @objc func closeGPXFilesTableViewController() {
@@ -255,4 +260,39 @@ class GPXFilesTableViewController: UITableViewController, UINavigationBarDelegat
         }
         self.present(activityViewController, animated: true, completion: nil)
     }
+    
+}
+
+extension GPXFilesTableViewController {
+    ///
+    /// Asks the system to notify the app on some events
+    ///
+    /// Current implementation requests the system to notify the app:
+    ///
+    ///  When a file is received from an external source, (i.e AirDrop)
+    ///
+    func addNotificationObservers() {
+        let notificationCenter = NotificationCenter.default
+        
+        notificationCenter.addObserver(self, selector: #selector(reloadTableData),
+                                       name: .didReceiveFileFromURL, object: nil)
+    }
+    
+    ///
+    /// Removes the notification observers
+    ///
+    func removeNotificationObservers() {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
+    @objc func reloadTableData() {
+        let list: [GPXFileInfo] = GPXFileManager.fileList
+        if self.fileList.count < list.count && list.count != 0 {
+            self.fileList.removeAllObjects()
+            self.fileList.addObjects(from: list)
+            self.gpxFilesFound = true
+            self.tableView.reloadData()
+        }
+    }
+    
 }

--- a/OpenGpxTracker/ViewController.swift
+++ b/OpenGpxTracker/ViewController.swift
@@ -9,7 +9,6 @@ import UIKit
 import CoreLocation
 import MapKit
 import CoreGPX
-import WatchConnectivity
 
 
 /// Purple color for button background
@@ -665,6 +664,7 @@ class ViewController: UIViewController, UIGestureRecognizerDelegate  {
     ///  1. whenever it enters background
     ///  2. whenever it becomes active
     ///  3. whenever it will terminate
+    ///  4. whenever it receives a file from Apple Watch
     ///
     func addNotificationObservers() {
         let notificationCenter = NotificationCenter.default
@@ -688,8 +688,9 @@ class ViewController: UIViewController, UIGestureRecognizerDelegate  {
         NotificationCenter.default.removeObserver(self)
     }
     
-    var fileNameFromAppleWatch = String()
-    
+    ///
+    /// Presents alert when file received from Apple Watch
+    ///
     @objc func presentReceivedFile(_ notification: Notification) {
         
         guard let fileName = notification.userInfo?["fileName"] as? String? else { return }


### PR DESCRIPTION
This fixes #91, and fixes https://github.com/merlos/iOS-Open-GPX-Tracker/issues/78#issuecomment-471555681

The `WCSessionDelegate` is also moved from `ViewController` to `AppDelegate`