### PR TITLE
Include elevation during waypoint generation, when possible

### DIFF
--- a/OpenGpxTracker/GPXWaypoint+MKAnnotation.swift
+++ b/OpenGpxTracker/GPXWaypoint+MKAnnotation.swift
@@ -41,9 +41,7 @@ extension GPXWaypoint : MKAnnotation {
     
     convenience init (coordinate: CLLocationCoordinate2D, altitude: CLLocationDistance?) {
         self.init(coordinate: coordinate)
-        if altitude != nil {
-            self.elevation = altitude
-        }
+        self.elevation = altitude
     }
     
     /// Title displayed on the annotation bubble.

--- a/OpenGpxTracker/GPXWaypoint+MKAnnotation.swift
+++ b/OpenGpxTracker/GPXWaypoint+MKAnnotation.swift
@@ -39,6 +39,13 @@ extension GPXWaypoint : MKAnnotation {
         self.subtitle = subtitleFormat.string(from: now)
     }
     
+    convenience init (coordinate: CLLocationCoordinate2D, altitude: CLLocationDistance?) {
+        self.init(coordinate: coordinate)
+        if altitude != nil {
+            self.elevation = altitude
+        }
+    }
+    
     /// Title displayed on the annotation bubble.
     /// Is the attribute name of the waypoint.
     public var title: String? {

--- a/OpenGpxTracker/MapViewDelegate.swift
+++ b/OpenGpxTracker/MapViewDelegate.swift
@@ -98,6 +98,7 @@ class MapViewDelegate: NSObject, MKMapViewDelegate, UIAlertViewDelegate {
         didChange newState: MKAnnotationView.DragState, fromOldState oldState: MKAnnotationView.DragState) {
         if newState == MKAnnotationView.DragState.ending {
             if let point = view.annotation as? GPXWaypoint {
+                point.elevation = nil
                 print("Annotation name: \(String(describing: point.title)) lat:\(String(describing:point.latitude)) lon \(String(describing:point.longitude))")
             }
         }

--- a/OpenGpxTracker/ViewController.swift
+++ b/OpenGpxTracker/ViewController.swift
@@ -847,7 +847,8 @@ class ViewController: UIViewController, UIGestureRecognizerDelegate  {
     ///
     @objc func addPinAtMyLocation() {
         print("Adding Pin at my location")
-        let waypoint = GPXWaypoint(coordinate: map.userLocation.coordinate)
+        let altitude = map.userLocation.location?.altitude
+        let waypoint = GPXWaypoint(coordinate: map.userLocation.coordinate, altitude: altitude)
         map.addWaypoint(waypoint)
         self.hasWaypoints = true
     }


### PR DESCRIPTION
This pull request allows elevation values to be logged in waypoint, when generating the waypoint using the add pin button. This is to partially resolve issue #102.

Possible scenario: 
- Only when adding pin using pin button.
- If waypoint with elevation is moved on map, elevation is removed, as it is irrelevant
- Waypoints added through other means will not have elevation value
- Editing of waypoint name should not remove elevation value
