### PR TITLE
UI Enhancements

### DIFF
--- a/OpenGpxTracker/GPXFilesTableViewController.swift
+++ b/OpenGpxTracker/GPXFilesTableViewController.swift
@@ -271,6 +271,7 @@ class GPXFilesTableViewController: UITableViewController, UINavigationBarDelegat
             alertController.view.addSubview(activityIndicatorView)
             
             self.present(alertController, animated: true, completion: nil)
+            activityIndicatorView.stopAnimating()
         }
         else {
             self.presentingViewController?.dismiss(animated: true, completion: nil)

--- a/OpenGpxTracker/GPXFilesTableViewController.swift
+++ b/OpenGpxTracker/GPXFilesTableViewController.swift
@@ -173,8 +173,12 @@ class GPXFilesTableViewController: UITableViewController, UINavigationBarDelegat
         sheet.addAction(shareOption)
         sheet.addAction(cancelOption)
         sheet.addAction(deleteOption)
+        
+        var cellRect = tableView.rectForRow(at: indexPath)
+        cellRect.origin = CGPoint(x: 0, y: 0) // origin must be at 0 or sheet will display offset due to height of cell
+        
         sheet.popoverPresentationController?.sourceView = tableView.cellForRow(at: indexPath)
-        sheet.popoverPresentationController?.sourceRect = (tableView.cellForRow(at: indexPath)?.frame)!
+        sheet.popoverPresentationController?.sourceRect = cellRect
         
         self.present(sheet, animated: true) {
             print("Loaded actionSheet")
@@ -287,8 +291,15 @@ class GPXFilesTableViewController: UITableViewController, UINavigationBarDelegat
         print("GPXTableViewController: actionShareFileAtIndex")
         
         let activityViewController = UIActivityViewController(activityItems: [gpxFileInfo.fileURL], applicationActivities: nil)
+        
+        var cellRect = tableView.rectForRow(at: indexPath)
+        cellRect.origin = CGPoint(x: 0, y: 0) // origin must be at 0 or sheet will display offset due to height of cell
+        
         activityViewController.popoverPresentationController?.sourceView = tableView.cellForRow(at: indexPath)
-        activityViewController.popoverPresentationController?.sourceRect = (tableView.cellForRow(at: indexPath)?.frame)!
+        activityViewController.popoverPresentationController?.sourceRect = cellRect
+        
+        // NOTE: as the activity view controller can be quite tall at times, the display of it may be offset automatically at times to ensure the activity view popup fits the screen.
+        
         activityViewController.completionWithItemsHandler = {(activityType: UIActivity.ActivityType?, completed: Bool, returnedItems: [Any]?, error: Error?) in
             if !completed {
                 // User canceled

--- a/OpenGpxTracker/GPXFilesTableViewController.swift
+++ b/OpenGpxTracker/GPXFilesTableViewController.swift
@@ -259,21 +259,21 @@ class GPXFilesTableViewController: UITableViewController, UINavigationBarDelegat
     
     /// Displays an alert with a activity indicator view to indicate loading of gpx file to map
     func displayLoadingFileAlert(_ loading: Bool, completion: (() -> Void)? = nil) {
-        if loading {
-            let alertController = UIAlertController(title: "Loading GPX File", message: nil, preferredStyle: .alert)
-            let activityIndicatorView = UIActivityIndicatorView(frame: CGRect(x: 35, y: 30, width: 32, height: 32))
-            activityIndicatorView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-            
+        // setup of controllers and views
+        let alertController = UIAlertController(title: "Loading GPX File...", message: nil, preferredStyle: .alert)
+        let activityIndicatorView = UIActivityIndicatorView(frame: CGRect(x: 35, y: 30, width: 32, height: 32))
+        activityIndicatorView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        activityIndicatorView.style = .whiteLarge
+        activityIndicatorView.color = .black
+        
+        if loading { // will display alert
             activityIndicatorView.startAnimating()
-            activityIndicatorView.style = .whiteLarge
-            activityIndicatorView.color = .black
-            
             alertController.view.addSubview(activityIndicatorView)
             
             self.present(alertController, animated: true, completion: nil)
-            activityIndicatorView.stopAnimating()
         }
-        else {
+        else { // will dismiss alert
+            activityIndicatorView.stopAnimating()
             self.presentingViewController?.dismiss(animated: true, completion: nil)
         }
         


### PR DESCRIPTION
For a long time, I have always felt that when loading, or using the share button on map, with large files can be slow, and that it isn't represented by anything, just freezing in the process.

For this pull request, the following is added:
1. When share button is tapped, it is animated to a spinning activity indicator, replacing the button, and the button will appear after its done
2. When loading a file from table view, an alert with a spinning activity indicator and "Loading GPX File..." is shown to let user know work is being done.
3. Fixes iPad popup presentation view placement issues from quite a while ago, where the UI placement is still off.

I believe that this would improve the user experience as when the app freezes, the user can't really tell if its doing something or not, and that this should visually show some form of work being done in the background.