### PR TITLE
Fixes uppercase file extension bug

### DIFF
--- a/OpenGpxTracker/GPXFileManager.swift
+++ b/OpenGpxTracker/GPXFileManager.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// GPX File extension
-let kFileExt = "gpx"
+let kFileExt = ["gpx", "GPX"]
 
 ///
 /// Class to handle actions with GPX files (save, delete, etc..)
@@ -53,7 +53,7 @@ class GPXFileManager: NSObject {
                         print(sortedURLs)
                         //Now we filter GPX Files
                         for (url, modificationDate, fileSize) in sortedURLs {
-                            if url.pathExtension == kFileExt {
+                            if kFileExt.contains(url.pathExtension) {
                                 GPXFiles.append(GPXFileInfo(fileURL: url))
                                 //GPXFiles.append(url.deletingPathExtension().lastPathComponent)
                                 print("\(modificationDate) \(modificationDate.timeAgo(numericDates: true)) \(fileSize)bytes -- \(url.deletingPathExtension().lastPathComponent)")
@@ -75,8 +75,8 @@ class GPXFileManager: NSObject {
         var fullURL = self.GPXFilesFolderURL.appendingPathComponent(filename)
         print("URLForFilename(\(filename): pathForFilename: \(fullURL)")
         //check if filename has extension
-        if fullURL.pathExtension != kFileExt {
-            fullURL = fullURL.appendingPathExtension(kFileExt)
+        if  !(kFileExt.contains(fullURL.pathExtension)) {
+            fullURL = fullURL.appendingPathExtension(kFileExt[0])
         }
         return fullURL
     }


### PR DESCRIPTION
Bug described in [comment #65 by @wallstudios](https://github.com/merlos/iOS-Open-GPX-Tracker/issues/65#issuecomment-513606304).

Basically, the file extension **.gpx** would show in the file manager, but not **.GPX**
That should not be expected behaviour, and this should fix the issue, but not #65 as a whole.