### PR TITLE
Removal of organization name

### DIFF
--- a/OpenGpxTracker.xcodeproj/project.pbxproj
+++ b/OpenGpxTracker.xcodeproj/project.pbxproj
@@ -521,7 +521,7 @@
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 1010;
 				LastUpgradeCheck = 1020;
-				ORGANIZATIONNAME = TransitBox;
+				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					898EECD419C49B5800B4B207 = {
 						CreatedOnToolsVersion = 6.0;


### PR DESCRIPTION
Don't see why this project would have an organization name.

New files created, will now not contain the copyright info, if this pull request is merged.