### PR TITLE
Fix for polyline glitch

### DIFF
--- a/OpenGpxTracker/MapViewDelegate.swift
+++ b/OpenGpxTracker/MapViewDelegate.swift
@@ -46,14 +46,14 @@ class MapViewDelegate: NSObject, MKMapViewDelegate, UIAlertViewDelegate {
         if overlay is MKPolyline {
             let pr = MKPolylineRenderer(overlay: overlay)
             
-            pr.alpha = 0.5
+            pr.alpha = 0.8
             pr.strokeColor = UIColor.blue
             
             if #available(iOS 13, *) {
                 pr.shouldRasterize = true
                 if mapView.traitCollection.userInterfaceStyle == .dark {
-                    pr.alpha = 0.2
-                    pr.strokeColor = UIColor.white
+                    pr.alpha = 0.5
+                    pr.strokeColor = UIColor.yellow
                 }
             }
             

--- a/OpenGpxTracker/MapViewDelegate.swift
+++ b/OpenGpxTracker/MapViewDelegate.swift
@@ -45,12 +45,18 @@ class MapViewDelegate: NSObject, MKMapViewDelegate, UIAlertViewDelegate {
         
         if overlay is MKPolyline {
             let pr = MKPolylineRenderer(overlay: overlay)
-            if #available(iOS 13, *), mapView.traitCollection.userInterfaceStyle == .dark {
-                pr.strokeColor = UIColor.white.withAlphaComponent(0.3)
+            
+            pr.alpha = 0.5
+            pr.strokeColor = UIColor.blue
+            
+            if #available(iOS 13, *) {
+                pr.shouldRasterize = true
+                if mapView.traitCollection.userInterfaceStyle == .dark {
+                    pr.alpha = 0.2
+                    pr.strokeColor = UIColor.white
+                }
             }
-            else {
-                pr.strokeColor = UIColor.blue.withAlphaComponent(0.5)
-            }
+            
             pr.lineWidth = 3
             return pr
         }


### PR DESCRIPTION
Fixes the glitch between polyline overlay and Apple maps rail line.

Apparently, its due to how it renders polyline as vectors than bitmap. `shouldRasterize` forces it to go back to pre iOS 13 style.

Apple docs: [shouldRasterize](https://developer.apple.com/documentation/mapkit/mkoverlaypathrenderer/3088846-shouldrasterize)