### PR TITLE
About page's dark mode support

### DIFF
--- a/OpenGpxTracker/about.html
+++ b/OpenGpxTracker/about.html
@@ -54,6 +54,22 @@
     ul > li:first-child {
         padding-top: 0px;
     }
+    
+    @media (prefers-color-scheme: dark) {
+        body {
+            background-color: #262626;
+            color: white;
+        }
+        a {
+            color: #7de3ff;
+        }
+        .tip span {
+            color: black;
+        }
+        .tip {
+            color: white;
+        }
+    }
 
     </style>
     


### PR DESCRIPTION
Well, almost everything's prep up with dark mode support, except for the about page.
This brings just that.