### PR TITLE
Fixes open files with the app (#137)

### DIFF
--- a/OpenGpxTracker/Info.plist
+++ b/OpenGpxTracker/Info.plist
@@ -17,12 +17,38 @@
 			<string>Editor</string>
 			<key>LSHandlerRank</key>
 			<string>Owner</string>
+            <key>UTTypeConformsTo</key>
+            <array>
+                <string>public.data</string>
+            </array>
 			<key>LSItemContentTypes</key>
 			<array>
 				<string>com.topografix.gpx</string>
 			</array>
 		</dict>
 	</array>
+    <key>UTExportedTypeDeclarations</key>
+    <array>
+        <dict>
+            <key>UTTypeConformsTo</key>
+            <array>
+                <string>public.data</string>
+            </array>
+            <key>UTTypeDescription</key>
+            <string>GPX File</string>
+            <key>UTTypeIconFiles</key>
+            <array/>
+            <key>UTTypeIdentifier</key>
+            <string>com.topografix.gpx</string>
+            <key>UTTypeTagSpecification</key>
+            <dict>
+                <key>public.filename-extension</key>
+                <array>
+                    <string>gpx</string>
+                </array>
+            </dict>
+        </dict>
+    </array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
This should fix the issue #137 

@vincentneo  For me what happened is that after installing the app with the fix, with airdrop I still got the dialog box with the App store /  Download in files (the one posted on the bug thread), Then on Files app  the file had a white icon, I selected to open it with Open GPX tracker and after that it always opened GPX files with the app.

Now,  I cannot reproduce this anymore... if I remove the app and install again it automatically links the GPX files with Open GPX Tracker.

According to this thread https://forums.developer.apple.com/thread/118932, it was a bug in iOS13

In the iPad I could not reproduce the bug at all. The bug can only be reproduced  when you have more than one app that opens gpx files in the device.
 