### PR TITLE
Fixes crash on > iOS 13 for hiding logo and text

### DIFF
--- a/OpenGpxTracker/GPXMapView.swift
+++ b/OpenGpxTracker/GPXMapView.swift
@@ -161,11 +161,13 @@ class GPXMapView: MKMapView {
     
     /// hides apple maps stuff when map tile != apple.
     func updateMapInformation(_ tileServer: GPXTileServer) {
-        if let mapLogo = self.subviews.filter({ $0.isKind(of:NSClassFromString("MKAppleLogoImageView")!) }).first {
+        if let logoClass = NSClassFromString("MKAppleLogoImageView"),
+           let mapLogo = self.subviews.filter({ $0.isKind(of: logoClass) }).first {
             mapLogo.isHidden = (tileServer != .apple)
         }
         
-        if let mapText = self.subviews.filter({ $0.isKind(of:NSClassFromString("MKAttributionLabel")!) }).first {
+        if let textClass = NSClassFromString("MKAttributionLabel"),
+           let mapText = self.subviews.filter({ $0.isKind(of: textClass) }).first {
             mapText.isHidden = (tileServer != .apple)
         }
     }


### PR DESCRIPTION
Well, because I implemented force unwraps for a class that doesn't exist < iOS 12..., in #140.

Also, I didn't want to use #available, just to prevent a possible app crash in future, if Apple decides to rename them.

