### PR TITLE
Better handling of color changes for dark mode

### DIFF
--- a/OpenGpxTracker.xcodeproj/project.pbxproj
+++ b/OpenGpxTracker.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		89F6E107227F7C5500CE3E3F /* Double+Measures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F6E0F4227D091900CE3E3F /* Double+Measures.swift */; };
 		89F8749B1BBB7362004EF41A /* GPXTrack+length.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F8749A1BBB7362004EF41A /* GPXTrack+length.swift */; };
 		89F8749F1BBCB97F004EF41A /* GPXRoot+length.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F8749E1BBCB97F004EF41A /* GPXRoot+length.swift */; };
+		BF15092223916FC100F51F1B /* UIColor+DarkMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF15092123916FC100F51F1B /* UIColor+DarkMode.swift */; };
 		BF1FE1A8230EAB9B00404B59 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = BF1FE1A6230EAB9B00404B59 /* Localizable.strings */; };
 		BF214B5E22E60B64000E96AA /* CLActivityType+Info.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF214B5D22E60B64000E96AA /* CLActivityType+Info.swift */; };
 		BF36B6CF220C6F1A00077B46 /* GPXFileTableInterfaceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF36B6CE220C6F1A00077B46 /* GPXFileTableInterfaceController.swift */; };
@@ -199,6 +200,7 @@
 		93BD71BED3CF101C2B01ABDA /* Pods_OpenGpxTracker_Watch_Extension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OpenGpxTracker_Watch_Extension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		95D28CBDF2535138FA16F38F /* Pods_OpenGpxTracker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OpenGpxTracker.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9A591D96EF2E41D00AD6BB3A /* Pods-OpenGpxTracker-Watch Extension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenGpxTracker-Watch Extension.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OpenGpxTracker-Watch Extension/Pods-OpenGpxTracker-Watch Extension.debug.xcconfig"; sourceTree = "<group>"; };
+		BF15092123916FC100F51F1B /* UIColor+DarkMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+DarkMode.swift"; sourceTree = "<group>"; };
 		BF1FE1A7230EAB9B00404B59 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		BF1FE1A9230EABA500404B59 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		BF214B5D22E60B64000E96AA /* CLActivityType+Info.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CLActivityType+Info.swift"; sourceTree = "<group>"; };
@@ -285,6 +287,7 @@
 				89EA86622157B42C002E03A7 /* GPXFileInfo.swift */,
 				BF6408A2225C63E700BB5242 /* CoreDataHelper.swift */,
 				BF214B5D22E60B64000E96AA /* CLActivityType+Info.swift */,
+				BF15092123916FC100F51F1B /* UIColor+DarkMode.swift */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -743,6 +746,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BF15092223916FC100F51F1B /* UIColor+DarkMode.swift in Sources */,
 				899D677F19D2366100C88A0A /* GPXMapView.swift in Sources */,
 				BF6408A3225C63E700BB5242 /* CoreDataHelper.swift in Sources */,
 				89E327BE1A7481EA00FC559E /* GPXTileServer.swift in Sources */,

--- a/OpenGpxTracker/GPXFilesTableViewController.swift
+++ b/OpenGpxTracker/GPXFilesTableViewController.swift
@@ -271,13 +271,10 @@ class GPXFilesTableViewController: UITableViewController, UINavigationBarDelegat
         activityIndicatorView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         activityIndicatorView.style = .whiteLarge
         
-        if #available(iOS 13, *), traitCollection.userInterfaceStyle == .dark {
-            activityIndicatorView.color = .white
+        if #available(iOS 13, *) {
+            activityIndicatorView.color = .blackAndWhite
         }
-        else {
-            activityIndicatorView.color = .black
-        }
-        
+
         if loading { // will display alert
             activityIndicatorView.startAnimating()
             alertController.view.addSubview(activityIndicatorView)

--- a/OpenGpxTracker/UIColor+DarkMode.swift
+++ b/OpenGpxTracker/UIColor+DarkMode.swift
@@ -1,0 +1,32 @@
+//
+//  UIColor+DarkMode.swift
+//  OpenGpxTracker
+//
+//  Created by Vincent on 29/11/19.
+//
+
+import UIKit
+
+@available(iOS 13.0, *)
+/// To better support dark mode color switches.
+extension UIColor {
+    
+    /// Main UI color
+    static let mainUIColor = UIColor { (traitCollection: UITraitCollection) -> UIColor in
+        switch traitCollection.userInterfaceStyle {
+            case .unspecified, .light:  return UIColor(red: 0, green: 0.61, blue: 0.86, alpha: 1)
+            case .dark:                 return .white
+            @unknown default:           return UIColor(red: 0, green: 0.61, blue: 0.86, alpha: 1)
+                }
+    }
+    
+    /// Returns a colour opposite of trait collection (i.e. light gets black, dark gets white.)
+    static let blackAndWhite = UIColor { (traitCollection: UITraitCollection) -> UIColor in
+        switch traitCollection.userInterfaceStyle {
+            case .unspecified, .light:  return .black
+            case .dark:                 return .white
+            @unknown default:           return .systemGray
+                }
+    }
+    
+}

--- a/OpenGpxTracker/ViewController.swift
+++ b/OpenGpxTracker/ViewController.swift
@@ -644,6 +644,10 @@ class ViewController: UIViewController, UIGestureRecognizerDelegate  {
         
         map.rotationGesture.delegate = self
         updateAppearance()
+        
+        if #available(iOS 13, *) {
+            shareActivityColor = .mainUIColor
+        }
     }
     
     /// Adds Constraints to subviews
@@ -808,13 +812,6 @@ class ViewController: UIViewController, UIGestureRecognizerDelegate  {
         if #available(iOS 13, *) {
             setNeedsStatusBarAppearanceUpdate()
             updatePolylineColor()
-            // activity indicator color
-            if map.traitCollection.userInterfaceStyle == .dark {
-                shareActivityColor = .white
-            }
-            else {
-                shareActivityColor = UIColor(red: 0, green: 0.61, blue: 0.86, alpha: 1)
-            }
         }
     }
     


### PR DESCRIPTION
I noticed that while the spinning indicator is shown, and if dark mode is switched, the spinner will not change colors.

This should fix it.