### PR TITLE
Implementation of custom default name preferences

### DIFF
--- a/OpenGpxTracker.xcodeproj/project.pbxproj
+++ b/OpenGpxTracker.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		BF6408A3225C63E700BB5242 /* CoreDataHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF6408A2225C63E700BB5242 /* CoreDataHelper.swift */; };
 		BF6428B8220EC1A90015447E /* GPXFileTableRowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF6428B7220EC1A90015447E /* GPXFileTableRowController.swift */; };
 		BF64602F220AE9CF00957FF6 /* GPXTrackSegment+MapKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 899D676B19CD9E9E00C88A0A /* GPXTrackSegment+MapKit.swift */; };
+		BF68ECC62448B887005C779F /* DateFieldTypeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF68ECC52448B887005C779F /* DateFieldTypeView.swift */; };
 		BF692F5D2209AAFB00F8A0F1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BF692F5C2209AAFB00F8A0F1 /* Assets.xcassets */; };
 		BF692F642209AAFB00F8A0F1 /* OpenGpxTracker-Watch Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = BF692F632209AAFB00F8A0F1 /* OpenGpxTracker-Watch Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		BF692F692209AAFB00F8A0F1 /* InterfaceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF692F682209AAFB00F8A0F1 /* InterfaceController.swift */; };
@@ -212,6 +213,7 @@
 		BF637D122216C5FA0003EC04 /* WatchConnectivity.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WatchConnectivity.framework; path = System/Library/Frameworks/WatchConnectivity.framework; sourceTree = SDKROOT; };
 		BF6408A2225C63E700BB5242 /* CoreDataHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataHelper.swift; sourceTree = "<group>"; };
 		BF6428B7220EC1A90015447E /* GPXFileTableRowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPXFileTableRowController.swift; sourceTree = "<group>"; };
+		BF68ECC52448B887005C779F /* DateFieldTypeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateFieldTypeView.swift; sourceTree = "<group>"; };
 		BF692F572209AAF900F8A0F1 /* OpenGpxTracker-Watch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "OpenGpxTracker-Watch.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BF692F5C2209AAFB00F8A0F1 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		BF692F5E2209AAFB00F8A0F1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -395,6 +397,7 @@
 				8913CD8D1BDB2477009EC729 /* PreferencesTableViewControllerDelegate.swift */,
 				DC4908A21C4A332E009484AE /* MapViewDelegate.swift */,
 				BF9AE57B2410011D00B103A0 /* DefaultNameSetupViewController.swift */,
+				BF68ECC52448B887005C779F /* DateFieldTypeView.swift */,
 			);
 			name = Controllers;
 			sourceTree = "<group>";
@@ -763,6 +766,7 @@
 				89E327BE1A7481EA00FC559E /* GPXTileServer.swift in Sources */,
 				898EECE019C49B5800B4B207 /* ViewController.swift in Sources */,
 				120DE71022B274910055C4CB /* GPXSession.swift in Sources */,
+				BF68ECC62448B887005C779F /* DateFieldTypeView.swift in Sources */,
 				BF9AE57E2410012700B103A0 /* DefaultDateFormat.swift in Sources */,
 				899D677019CE024600C88A0A /* GPXFileManager.swift in Sources */,
 				898EECDE19C49B5800B4B207 /* OpenGpxTracker.xcdatamodeld in Sources */,

--- a/OpenGpxTracker.xcodeproj/project.pbxproj
+++ b/OpenGpxTracker.xcodeproj/project.pbxproj
@@ -79,6 +79,11 @@
 		BF9AE57C2410011D00B103A0 /* DefaultNameSetupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9AE57B2410011D00B103A0 /* DefaultNameSetupViewController.swift */; };
 		BF9AE57E2410012700B103A0 /* DefaultDateFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9AE57D2410012700B103A0 /* DefaultDateFormat.swift */; };
 		BFA3CE8222C23B2300A8B965 /* CoreDataAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA3CE8122C23B2300A8B965 /* CoreDataAlertView.swift */; };
+		BFB06F02244A037300AC0CDC /* UIColor+Keyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFB06F01244A037300AC0CDC /* UIColor+Keyboard.swift */; };
+		BFE026C0244A0160005423E6 /* String+CountInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE026BF244A0160005423E6 /* String+CountInstances.swift */; };
+		BFE026C2244A01DB005423E6 /* UIInsetLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE026C1244A01DB005423E6 /* UIInsetLabel.swift */; };
+		BFE026C4244A0281005423E6 /* DateField.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE026C3244A0281005423E6 /* DateField.swift */; };
+		BFE026C6244A02A4005423E6 /* DateFieldButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE026C5244A02A4005423E6 /* DateFieldButton.swift */; };
 		BFF3047F2312DC1D0012D263 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = BF1FE1A6230EAB9B00404B59 /* Localizable.strings */; };
 		BFF304802312DC1F0012D263 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = BF1FE1A6230EAB9B00404B59 /* Localizable.strings */; };
 		BFF304812312DC700012D263 /* Interface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 45A430EB230D61240003C2F2 /* Interface.storyboard */; };
@@ -226,6 +231,11 @@
 		BF9AE57B2410011D00B103A0 /* DefaultNameSetupViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultNameSetupViewController.swift; sourceTree = "<group>"; };
 		BF9AE57D2410012700B103A0 /* DefaultDateFormat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultDateFormat.swift; sourceTree = "<group>"; };
 		BFA3CE8122C23B2300A8B965 /* CoreDataAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataAlertView.swift; sourceTree = "<group>"; };
+		BFB06F01244A037300AC0CDC /* UIColor+Keyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Keyboard.swift"; sourceTree = "<group>"; };
+		BFE026BF244A0160005423E6 /* String+CountInstances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+CountInstances.swift"; sourceTree = "<group>"; };
+		BFE026C1244A01DB005423E6 /* UIInsetLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIInsetLabel.swift; sourceTree = "<group>"; };
+		BFE026C3244A0281005423E6 /* DateField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateField.swift; sourceTree = "<group>"; };
+		BFE026C5244A02A4005423E6 /* DateFieldButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFieldButton.swift; sourceTree = "<group>"; };
 		BFF3047A2312D8A00012D263 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Main.strings"; sourceTree = "<group>"; };
 		BFF3047B2312D8A00012D263 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Interface.strings"; sourceTree = "<group>"; };
 		BFF3047C2312D8A00012D263 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
@@ -299,6 +309,10 @@
 				BF6408A2225C63E700BB5242 /* CoreDataHelper.swift */,
 				BF214B5D22E60B64000E96AA /* CLActivityType+Info.swift */,
 				BF15092123916FC100F51F1B /* UIColor+DarkMode.swift */,
+				BFE026BF244A0160005423E6 /* String+CountInstances.swift */,
+				BFE026C1244A01DB005423E6 /* UIInsetLabel.swift */,
+				BFE026C3244A0281005423E6 /* DateField.swift */,
+				BFB06F01244A037300AC0CDC /* UIColor+Keyboard.swift */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -397,7 +411,6 @@
 				8913CD8D1BDB2477009EC729 /* PreferencesTableViewControllerDelegate.swift */,
 				DC4908A21C4A332E009484AE /* MapViewDelegate.swift */,
 				BF9AE57B2410011D00B103A0 /* DefaultNameSetupViewController.swift */,
-				BF68ECC52448B887005C779F /* DateFieldTypeView.swift */,
 			);
 			name = Controllers;
 			sourceTree = "<group>";
@@ -409,6 +422,8 @@
 				BF5C0D2122D771D0001C2575 /* DistanceLabel.swift */,
 				BFA3CE8122C23B2300A8B965 /* CoreDataAlertView.swift */,
 				DC4908A01C4A136F009484AE /* TrackerButton.swift */,
+				BFE026C5244A02A4005423E6 /* DateFieldButton.swift */,
+				BF68ECC52448B887005C779F /* DateFieldTypeView.swift */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -760,6 +775,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BFE026C6244A02A4005423E6 /* DateFieldButton.swift in Sources */,
 				BF15092223916FC100F51F1B /* UIColor+DarkMode.swift in Sources */,
 				899D677F19D2366100C88A0A /* GPXMapView.swift in Sources */,
 				BF6408A3225C63E700BB5242 /* CoreDataHelper.swift in Sources */,
@@ -777,6 +793,7 @@
 				8913CD8E1BDB2477009EC729 /* PreferencesTableViewControllerDelegate.swift in Sources */,
 				899D676E19CD9FAF00C88A0A /* GPXTrackPoint+MapKit.swift in Sources */,
 				89F8749B1BBB7362004EF41A /* GPXTrack+length.swift in Sources */,
+				BFB06F02244A037300AC0CDC /* UIColor+Keyboard.swift in Sources */,
 				BFA3CE8222C23B2300A8B965 /* CoreDataAlertView.swift in Sources */,
 				899D678219D351DA00C88A0A /* AboutViewController.swift in Sources */,
 				89EA86612157A08E002E03A7 /* Date+timeAgo.swift in Sources */,
@@ -789,6 +806,9 @@
 				899D676C19CD9E9E00C88A0A /* GPXTrackSegment+MapKit.swift in Sources */,
 				899D677219CE8B3600C88A0A /* StopWatch.swift in Sources */,
 				89F6E0F7227E107C00CE3E3F /* Preferences.swift in Sources */,
+				BFE026C0244A0160005423E6 /* String+CountInstances.swift in Sources */,
+				BFE026C4244A0281005423E6 /* DateField.swift in Sources */,
+				BFE026C2244A01DB005423E6 /* UIInsetLabel.swift in Sources */,
 				BF9AE57C2410011D00B103A0 /* DefaultNameSetupViewController.swift in Sources */,
 				893BEC8619C7E62200C77354 /* GPXWaypoint+MKAnnotation.swift in Sources */,
 				DC4908A31C4A332E009484AE /* MapViewDelegate.swift in Sources */,

--- a/OpenGpxTracker.xcodeproj/project.pbxproj
+++ b/OpenGpxTracker.xcodeproj/project.pbxproj
@@ -75,6 +75,8 @@
 		BF692F872209B81A00F8A0F1 /* Int+asFilesize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89EA86642157C444002E03A7 /* Int+asFilesize.swift */; };
 		BF692F882209B81E00F8A0F1 /* GPXFileInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89EA86622157B42C002E03A7 /* GPXFileInfo.swift */; };
 		BF692F892209B82500F8A0F1 /* StopWatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 899D677119CE8B3600C88A0A /* StopWatch.swift */; };
+		BF9AE57C2410011D00B103A0 /* DefaultNameSetupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9AE57B2410011D00B103A0 /* DefaultNameSetupViewController.swift */; };
+		BF9AE57E2410012700B103A0 /* DefaultDateFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9AE57D2410012700B103A0 /* DefaultDateFormat.swift */; };
 		BFA3CE8222C23B2300A8B965 /* CoreDataAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA3CE8122C23B2300A8B965 /* CoreDataAlertView.swift */; };
 		BFF3047F2312DC1D0012D263 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = BF1FE1A6230EAB9B00404B59 /* Localizable.strings */; };
 		BFF304802312DC1F0012D263 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = BF1FE1A6230EAB9B00404B59 /* Localizable.strings */; };
@@ -219,6 +221,8 @@
 		BF692F6C2209AAFB00F8A0F1 /* ComplicationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComplicationController.swift; sourceTree = "<group>"; };
 		BF692F6E2209AAFC00F8A0F1 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		BF692F702209AAFC00F8A0F1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		BF9AE57B2410011D00B103A0 /* DefaultNameSetupViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultNameSetupViewController.swift; sourceTree = "<group>"; };
+		BF9AE57D2410012700B103A0 /* DefaultDateFormat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultDateFormat.swift; sourceTree = "<group>"; };
 		BFA3CE8122C23B2300A8B965 /* CoreDataAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataAlertView.swift; sourceTree = "<group>"; };
 		BFF3047A2312D8A00012D263 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Main.strings"; sourceTree = "<group>"; };
 		BFF3047B2312D8A00012D263 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Interface.strings"; sourceTree = "<group>"; };
@@ -276,6 +280,7 @@
 		8948550619CB954100AB366A /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				BF9AE57D2410012700B103A0 /* DefaultDateFormat.swift */,
 				89F6E104227F7BD000CE3E3F /* shared */,
 				899D677119CE8B3600C88A0A /* StopWatch.swift */,
 				893BEC8519C7E62200C77354 /* GPXWaypoint+MKAnnotation.swift */,
@@ -389,6 +394,7 @@
 				8913CD8B1BDB0A9A009EC729 /* PreferencesTableViewController.swift */,
 				8913CD8D1BDB2477009EC729 /* PreferencesTableViewControllerDelegate.swift */,
 				DC4908A21C4A332E009484AE /* MapViewDelegate.swift */,
+				BF9AE57B2410011D00B103A0 /* DefaultNameSetupViewController.swift */,
 			);
 			name = Controllers;
 			sourceTree = "<group>";
@@ -757,6 +763,7 @@
 				89E327BE1A7481EA00FC559E /* GPXTileServer.swift in Sources */,
 				898EECE019C49B5800B4B207 /* ViewController.swift in Sources */,
 				120DE71022B274910055C4CB /* GPXSession.swift in Sources */,
+				BF9AE57E2410012700B103A0 /* DefaultDateFormat.swift in Sources */,
 				899D677019CE024600C88A0A /* GPXFileManager.swift in Sources */,
 				898EECDE19C49B5800B4B207 /* OpenGpxTracker.xcdatamodeld in Sources */,
 				89EA86652157C444002E03A7 /* Int+asFilesize.swift in Sources */,
@@ -778,6 +785,7 @@
 				899D676C19CD9E9E00C88A0A /* GPXTrackSegment+MapKit.swift in Sources */,
 				899D677219CE8B3600C88A0A /* StopWatch.swift in Sources */,
 				89F6E0F7227E107C00CE3E3F /* Preferences.swift in Sources */,
+				BF9AE57C2410011D00B103A0 /* DefaultNameSetupViewController.swift in Sources */,
 				893BEC8619C7E62200C77354 /* GPXWaypoint+MKAnnotation.swift in Sources */,
 				DC4908A31C4A332E009484AE /* MapViewDelegate.swift in Sources */,
 				898EED3619C6402900B4B207 /* GPXFilesTableViewController.swift in Sources */,

--- a/OpenGpxTracker.xcodeproj/project.pbxproj
+++ b/OpenGpxTracker.xcodeproj/project.pbxproj
@@ -83,7 +83,7 @@
 		BFE026C0244A0160005423E6 /* String+CountInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE026BF244A0160005423E6 /* String+CountInstances.swift */; };
 		BFE026C2244A01DB005423E6 /* UIInsetLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE026C1244A01DB005423E6 /* UIInsetLabel.swift */; };
 		BFE026C4244A0281005423E6 /* DateField.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE026C3244A0281005423E6 /* DateField.swift */; };
-		BFE026C6244A02A4005423E6 /* DateFieldButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE026C5244A02A4005423E6 /* DateFieldButton.swift */; };
+		BFE026C6244A02A4005423E6 /* DatePatternButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE026C5244A02A4005423E6 /* DatePatternButton.swift */; };
 		BFF3047F2312DC1D0012D263 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = BF1FE1A6230EAB9B00404B59 /* Localizable.strings */; };
 		BFF304802312DC1F0012D263 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = BF1FE1A6230EAB9B00404B59 /* Localizable.strings */; };
 		BFF304812312DC700012D263 /* Interface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 45A430EB230D61240003C2F2 /* Interface.storyboard */; };
@@ -235,7 +235,7 @@
 		BFE026BF244A0160005423E6 /* String+CountInstances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+CountInstances.swift"; sourceTree = "<group>"; };
 		BFE026C1244A01DB005423E6 /* UIInsetLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIInsetLabel.swift; sourceTree = "<group>"; };
 		BFE026C3244A0281005423E6 /* DateField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateField.swift; sourceTree = "<group>"; };
-		BFE026C5244A02A4005423E6 /* DateFieldButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFieldButton.swift; sourceTree = "<group>"; };
+		BFE026C5244A02A4005423E6 /* DatePatternButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePatternButton.swift; sourceTree = "<group>"; };
 		BFF3047A2312D8A00012D263 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Main.strings"; sourceTree = "<group>"; };
 		BFF3047B2312D8A00012D263 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Interface.strings"; sourceTree = "<group>"; };
 		BFF3047C2312D8A00012D263 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
@@ -292,7 +292,6 @@
 		8948550619CB954100AB366A /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				BF9AE57D2410012700B103A0 /* DefaultDateFormat.swift */,
 				89F6E104227F7BD000CE3E3F /* shared */,
 				899D677119CE8B3600C88A0A /* StopWatch.swift */,
 				893BEC8519C7E62200C77354 /* GPXWaypoint+MKAnnotation.swift */,
@@ -309,10 +308,11 @@
 				BF6408A2225C63E700BB5242 /* CoreDataHelper.swift */,
 				BF214B5D22E60B64000E96AA /* CLActivityType+Info.swift */,
 				BF15092123916FC100F51F1B /* UIColor+DarkMode.swift */,
+				BFB06F01244A037300AC0CDC /* UIColor+Keyboard.swift */,
 				BFE026BF244A0160005423E6 /* String+CountInstances.swift */,
 				BFE026C1244A01DB005423E6 /* UIInsetLabel.swift */,
 				BFE026C3244A0281005423E6 /* DateField.swift */,
-				BFB06F01244A037300AC0CDC /* UIColor+Keyboard.swift */,
+				BF9AE57D2410012700B103A0 /* DefaultDateFormat.swift */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -422,7 +422,7 @@
 				BF5C0D2122D771D0001C2575 /* DistanceLabel.swift */,
 				BFA3CE8122C23B2300A8B965 /* CoreDataAlertView.swift */,
 				DC4908A01C4A136F009484AE /* TrackerButton.swift */,
-				BFE026C5244A02A4005423E6 /* DateFieldButton.swift */,
+				BFE026C5244A02A4005423E6 /* DatePatternButton.swift */,
 				BF68ECC52448B887005C779F /* DateFieldTypeView.swift */,
 			);
 			name = Views;
@@ -775,7 +775,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BFE026C6244A02A4005423E6 /* DateFieldButton.swift in Sources */,
+				BFE026C6244A02A4005423E6 /* DatePatternButton.swift in Sources */,
 				BF15092223916FC100F51F1B /* UIColor+DarkMode.swift in Sources */,
 				899D677F19D2366100C88A0A /* GPXMapView.swift in Sources */,
 				BF6408A3225C63E700BB5242 /* CoreDataHelper.swift in Sources */,

--- a/OpenGpxTracker/DateField.swift
+++ b/OpenGpxTracker/DateField.swift
@@ -1,0 +1,23 @@
+//
+//  DateField.swift
+//  OpenGpxTracker
+//
+//  Created by Vincent Neo on 17/4/20.
+//
+
+import Foundation
+
+/// To hold each date pattern type for `DateFieldTypeView`
+struct DateField {
+    
+    /// Title/type of the pattern (e.g. Year / Second)
+    var type: String
+    
+    /// Patterns of that falls under said type (e.g `YYYY` / `ss`)
+    var patterns: [String]
+    
+    /// To facilitate explanation of said pattern, that falls under same type, if needed.
+    ///
+    /// Key of subtitle should be accessible in `patterns`
+    var subtitles: [String : String]?
+}

--- a/OpenGpxTracker/DateFieldButton.swift
+++ b/OpenGpxTracker/DateFieldButton.swift
@@ -1,0 +1,34 @@
+//
+//  DateFieldButton.swift
+//  OpenGpxTracker
+//
+//  Created by Vincent Neo on 17/4/20.
+//
+
+import UIKit
+
+class DateFieldButton: UIButton {
+    
+    var pattern = String()
+    
+    override var isSelected: Bool {
+        didSet {
+            if #available(iOS 13.0, *) {
+                backgroundColor = isSelected ?  .highlightKeyboardColor : .keyboardColor
+            } else {
+                backgroundColor = isSelected ?  .highlightLightKeyboard : .lightKeyboard
+            }
+        }
+    }
+    
+    override var isHighlighted: Bool {
+        didSet {
+            if #available(iOS 13.0, *) {
+                backgroundColor = isHighlighted ?  .highlightKeyboardColor : .keyboardColor
+            } else {
+                backgroundColor = isHighlighted ?  .highlightLightKeyboard : .darkKeyboard
+            }
+        }
+    }
+    
+}

--- a/OpenGpxTracker/DateFieldTypeView.swift
+++ b/OpenGpxTracker/DateFieldTypeView.swift
@@ -1,0 +1,253 @@
+//
+//  DateFieldTypeView.swift
+//  OpenGpxTracker
+//
+//  Created by Vincent Neo on 15/4/20.
+//
+
+import UIKit
+
+struct DateField {
+    var title: String
+    var patterns: [String]
+    var subtitles: [String : String]?
+}
+
+class UIInsetLabel: UILabel {
+    var insets = UIEdgeInsets.zero
+    
+    override func drawText(in rect: CGRect) {
+        super.drawText(in: rect.inset(by: insets))
+    }
+    
+    override var intrinsicContentSize: CGSize {
+        var size = super.intrinsicContentSize
+        
+        size.width += insets.left + insets.right
+        size.height += insets.top + insets.bottom
+
+        return size
+    }
+
+}
+
+
+class DateFieldButton: UIButton {
+    
+    var pattern = String()
+    
+    override var isSelected: Bool {
+        didSet {
+            if #available(iOS 13.0, *) {
+                backgroundColor = isSelected ?  .highlightKeyboardColor : .keyboardColor
+            } else {
+                backgroundColor = isSelected ?  .highlightLightKeyboard : .lightKeyboard
+            }
+        }
+    }
+    
+    override var isHighlighted: Bool {
+        didSet {
+            if #available(iOS 13.0, *) {
+                backgroundColor = isHighlighted ?  .highlightKeyboardColor : .keyboardColor
+            } else {
+                backgroundColor = isHighlighted ?  .highlightLightKeyboard : .darkKeyboard
+            }
+        }
+    }
+    
+}
+
+@available(iOS 9.0, *)
+class DateFieldTypeView: UIScrollView {
+        
+    let dateFormatter = DateFormatter()
+    
+    //public var fieldType: DateFieldType
+    var dateFields: [DateField] {
+        get {
+            var fields = [DateField]()
+            fields.append(DateField(title: "Year",
+                                    patterns: ["YY", "YYYY"]))
+            fields.append(DateField(title: "Month",
+                                    patterns: ["M", "MM", "MMMMM", "MMM", "MMMM"],
+                                    subtitles: ["M" : "Single",
+                                                "MMMMM" : "•",
+                                                "MMM" : "• • •",
+                                                "MMMM" : "Full"]))
+            // some subtitles are an attempt to clarify, in case of different Locales, causing some example of patterns to look the same.
+            fields.append(DateField(title: "Day",
+                                    patterns: ["d", "dd", "D"],
+                                    subtitles: ["d" : "Single",
+                                                "dd" : "Of Month",
+                                                "D" : "Of Year"]))
+            fields.append(DateField(title: "Hour",
+                                    patterns: ["h", "hh", "H", "HH", "K", "KK", "k", "kk"],
+                                    subtitles: ["h" : "Single", "hh" : "12hr",
+                                                "H" : "Single", "HH" : "24hr",
+                                                "K" : "Single", "KK" : "0-11",
+                                                "k" : "Single", "kk" : "1-24"]))
+            fields.append(DateField(title: "Minute",
+                                    patterns: ["m", "mm"],
+                                    subtitles: ["m" : "Single"]))
+            fields.append(DateField(title: "Second",
+                                    patterns: ["s", "ss"],
+                                    subtitles: ["s" : "Single"]))
+            fields.append(DateField(title: "Day of the Week",
+                                    patterns: ["e", "ee", "EEEEE", "EEEEEE", "E", "EEEE"],
+                                    subtitles: ["e" : "Single",
+                                                "EEEEE" : "•",
+                                                "EEEEEE" : "• •",
+                                                "E" : "• • •",
+                                                "EEEE" : "Full"]))
+            fields.append(DateField(title: "Period",
+                                    patterns: ["aaaaa", "a", "B"],
+                                    subtitles: ["aaaaa" : "Single", "B" : "Text"]))
+            fields.append(DateField(title: "Week",
+                                    patterns: ["w", "ww", "W"],
+                                    subtitles: ["w" : "Single", "ww" : "Of Year", "W" : "Of Month"]))
+            fields.append(DateField(title: "Quarter",
+                                    patterns: ["Q", "QQ", "QQQ", "QQQQ"]))
+            fields.append(DateField(title: "Era",
+                                    patterns: ["GGGGG", "G", "GGGG"]))
+            fields.append(DateField(title: "Time Zone",
+                                    patterns: ["X", "Z", "ZZZZZ", "z", "O", "ZZZZ", "zzzz", "VVV", "VVVV"],
+                                    subtitles: ["z" : "Abbr. / GMT",
+                                                "zzzz" : "Full",
+                                                "X" : "GMT Offset",
+                                                "O" : "GMT Short",
+                                                "ZZZZ" : "GMT Full",
+                                                "VVV" : "Location",
+                                                "VVVV" : "Location's Time"]))
+        
+            return fields
+        }
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        viewDidInit()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        viewDidInit()
+    }
+    
+    func viewDidInit() {
+        if #available(iOS 13.0, *) {
+            self.backgroundColor = .keyboardColor
+        } else {
+            self.backgroundColor = .lightKeyboard
+        }
+        let scrollStack = UIStackView()
+        scrollStack.axis = .horizontal
+        scrollStack.distribution = .fill
+        scrollStack.alignment = .leading
+        scrollStack.spacing = 25
+        scrollStack.translatesAutoresizingMaskIntoConstraints = false
+        
+        for field in dateFields {
+            let vStack = genVStack(field: field)
+            scrollStack.addArrangedSubview(vStack)
+        }
+        
+        self.addSubview(scrollStack)
+        self.addConstraints( NSLayoutConstraint.constraints(withVisualFormat: "H:|-20-[sStack]-20-|", options: NSLayoutConstraint.FormatOptions(rawValue: 0), metrics: nil, views: ["sStack": scrollStack])
+        )
+
+    }
+    
+    func genVStack(field: DateField) -> UIStackView {
+        let vStack = UIStackView()
+        vStack.axis = .vertical
+        vStack.distribution = .fill
+        vStack.alignment = .leading
+        vStack.spacing = 0
+        vStack.translatesAutoresizingMaskIntoConstraints = false
+        
+        let textTitle = UIInsetLabel()
+        textTitle.text = field.title.uppercased()
+        textTitle.textColor = .gray
+        textTitle.font = .boldSystemFont(ofSize: 14)
+        textTitle.insets = UIEdgeInsets(top: 5, left: 5, bottom: 0, right: 0)
+        
+        vStack.addArrangedSubview(textTitle)
+        vStack.addArrangedSubview(genHStack(field: field))
+        
+        return vStack
+        
+    }
+    
+    func genHStack(field: DateField) -> UIStackView {
+        
+        let hStack = UIStackView()
+        hStack.axis = .horizontal
+        hStack.distribution = .fill
+        hStack.alignment = .leading
+        hStack.spacing = 10
+        hStack.translatesAutoresizingMaskIntoConstraints = false
+        
+        for pattern in field.patterns {
+            let button = DateFieldButton(type: .custom)
+            button.layer.cornerRadius = 10
+
+            dateFormatter.dateFormat = pattern
+            let realPattern = dateFormatter.string(from: Date())
+            
+            button.setTitle(realPattern, for: .normal)
+            button.titleLabel?.text = realPattern
+            button.contentEdgeInsets = UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 5)
+            
+            if #available(iOS 13, *) {
+                button.setTitleColor(.blackAndWhite, for: .normal)
+            }
+            else {
+                button.setTitleColor(.black, for: .normal)
+            }
+            button.pattern = pattern
+            
+            button.addTarget(self, action: #selector(buttonTapped(sender:)), for: .touchUpInside)
+
+            
+            if let subtitle = field.subtitles?[pattern] {
+                let subtitleLabel = UIInsetLabel()
+                let subVStack = UIStackView()
+                subVStack.axis = .vertical
+                subVStack.distribution = .fill
+                subVStack.alignment = .leading
+                subVStack.spacing = -2.5
+                subVStack.translatesAutoresizingMaskIntoConstraints = false
+                
+                subtitleLabel.insets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+                subtitleLabel.text = subtitle.uppercased()
+                subtitleLabel.font = .boldSystemFont(ofSize: 8)
+                subtitleLabel.textAlignment = .center
+                
+                subVStack.addArrangedSubview(button)
+                subVStack.addArrangedSubview(subtitleLabel)
+                NSLayoutConstraint(item: subtitleLabel, attribute: .width, relatedBy: .equal, toItem: button, attribute: .width, multiplier: 1, constant: 0).isActive = true
+                hStack.addArrangedSubview(subVStack)
+            }
+            else {
+                hStack.addArrangedSubview(button)
+            }
+
+        }
+        
+        return hStack
+    }
+    
+    @objc func buttonTapped(sender: DateFieldButton) {
+        NotificationCenter.default.post(name: .dateFieldTapped, object: nil, userInfo: ["sender" : sender.pattern])
+    }
+
+    
+}
+/// Notifications for file receival from external source.
+extension Notification.Name {
+    
+    /// When date field type is tapped from view.
+    static let dateFieldTapped = Notification.Name("dateFieldTapped")
+    
+}

--- a/OpenGpxTracker/DateFieldTypeView.swift
+++ b/OpenGpxTracker/DateFieldTypeView.swift
@@ -7,11 +7,14 @@
 
 import UIKit
 
+/// View that is meant to be attached above keyboard, supplementing default name inputs.
 @available(iOS 9.0, *)
 class DateFieldTypeView: UIScrollView {
-        
+    
+    /// date formatter to display current time example
     private let dateFormatter = DateFormatter()
     
+    /// valid date fields that are to be displayed.
     private var dateFields: [DateField] {
         get {
             var fields = [DateField]()
@@ -48,12 +51,15 @@ class DateFieldTypeView: UIScrollView {
                                                 "EEEEEE" : "• •",
                                                 "E" : "• • •",
                                                 "EEEE" : "Full"]))
-            fields.append(DateField(type: "Period",
+            fields.append(DateField(type: "Time of Day",
                                     patterns: ["aaaaa", "a", "B"],
-                                    subtitles: ["aaaaa" : "Single", "B" : "Text"]))
+                                    subtitles: ["aaaaa" : "Single",
+                                                "B" : "Text"]))
             fields.append(DateField(type: "Week",
                                     patterns: ["w", "ww", "W"],
-                                    subtitles: ["w" : "Single", "ww" : "Of Year", "W" : "Of Month"]))
+                                    subtitles: ["w" : "Single",
+                                                "ww" : "Of Year",
+                                                "W" : "Of Month"]))
             fields.append(DateField(type: "Quarter",
                                     patterns: ["Q", "QQ", "QQQ", "QQQQ"]))
             fields.append(DateField(type: "Era",
@@ -71,23 +77,28 @@ class DateFieldTypeView: UIScrollView {
             return fields
         }
     }
-    
+    /// Default initializer
     override init(frame: CGRect) {
         super.init(frame: frame)
         viewDidInit()
     }
     
+    /// Default initializer
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         viewDidInit()
     }
     
+    
+    /// Things to do, when view successfully inits.
     func viewDidInit() {
         if #available(iOS 13.0, *) {
             self.backgroundColor = .keyboardColor
         } else {
             self.backgroundColor = .lightKeyboard
         }
+        
+        // holds everything
         let scrollStack = UIStackView()
         scrollStack.axis = .horizontal
         scrollStack.distribution = .fill
@@ -101,11 +112,15 @@ class DateFieldTypeView: UIScrollView {
         }
         
         self.addSubview(scrollStack)
-        self.addConstraints( NSLayoutConstraint.constraints(withVisualFormat: "H:|-20-[sStack]-20-|", options: NSLayoutConstraint.FormatOptions(rawValue: 0), metrics: nil, views: ["sStack": scrollStack])
-        )
+        self.addConstraints( NSLayoutConstraint.constraints(withVisualFormat: "H:|-20-[sStack]-20-|", options: .alignAllLeft, metrics: nil, views: ["sStack": scrollStack]) )
 
     }
     
+    /// Generates vertical stack that encapsulates text title, with all date patterns of same type.
+    ///
+    ///     |TYPE|
+    ///     |genHStack(field:)|
+    ///
     func genVStack(field: DateField) -> UIStackView {
         let vStack = UIStackView()
         vStack.axis = .vertical
@@ -127,6 +142,11 @@ class DateFieldTypeView: UIScrollView {
         
     }
     
+    /// Generates horizontal stack that encapsulates all date patterns of same type.
+    ///
+    ///     |pattern|pattern|pattern|
+    ///     |SUBTITLE|SUBTITLE|
+    ///
     func genHStack(field: DateField) -> UIStackView {
         
         let hStack = UIStackView()
@@ -137,27 +157,30 @@ class DateFieldTypeView: UIScrollView {
         hStack.translatesAutoresizingMaskIntoConstraints = false
         
         for pattern in field.patterns {
-            let button = DateFieldButton(type: .custom)
+            let button = DatePatternButton(type: .custom)
             button.layer.cornerRadius = 10
 
             dateFormatter.dateFormat = pattern
-            let realPattern = dateFormatter.string(from: Date())
-            
-            button.setTitle(realPattern, for: .normal)
-            button.titleLabel?.text = realPattern
+            let currentDateExample = dateFormatter.string(from: Date())
+            button.setTitle(currentDateExample, for: .normal)
+            button.titleLabel?.text = currentDateExample
             button.contentEdgeInsets = UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 5)
             
+            // color of button font
             if #available(iOS 13, *) {
                 button.setTitleColor(.blackAndWhite, for: .normal)
             }
             else {
                 button.setTitleColor(.black, for: .normal)
             }
+            
+            // for passing pattern to textField when needed
             button.pattern = pattern
             
             button.addTarget(self, action: #selector(buttonTapped(sender:)), for: .touchUpInside)
 
             
+            // Subtitle implementation (optional)
             if let subtitle = field.subtitles?[pattern] {
                 let subtitleLabel = UIInsetLabel()
                 let subVStack = UIStackView()
@@ -186,13 +209,14 @@ class DateFieldTypeView: UIScrollView {
         return hStack
     }
     
-    @objc func buttonTapped(sender: DateFieldButton) {
+    /// Called when any pattern button is tapped.
+    @objc func buttonTapped(sender: DatePatternButton) {
         NotificationCenter.default.post(name: .dateFieldTapped, object: nil, userInfo: ["sender" : sender.pattern])
     }
 
     
 }
-/// Notifications for file receival from external source.
+/// Notifications name of for date pattern sending
 extension Notification.Name {
     
     /// When date field type is tapped from view.

--- a/OpenGpxTracker/DateFieldTypeView.swift
+++ b/OpenGpxTracker/DateFieldTypeView.swift
@@ -7,110 +7,58 @@
 
 import UIKit
 
-struct DateField {
-    var title: String
-    var patterns: [String]
-    var subtitles: [String : String]?
-}
-
-class UIInsetLabel: UILabel {
-    var insets = UIEdgeInsets.zero
-    
-    override func drawText(in rect: CGRect) {
-        super.drawText(in: rect.inset(by: insets))
-    }
-    
-    override var intrinsicContentSize: CGSize {
-        var size = super.intrinsicContentSize
-        
-        size.width += insets.left + insets.right
-        size.height += insets.top + insets.bottom
-
-        return size
-    }
-
-}
-
-
-class DateFieldButton: UIButton {
-    
-    var pattern = String()
-    
-    override var isSelected: Bool {
-        didSet {
-            if #available(iOS 13.0, *) {
-                backgroundColor = isSelected ?  .highlightKeyboardColor : .keyboardColor
-            } else {
-                backgroundColor = isSelected ?  .highlightLightKeyboard : .lightKeyboard
-            }
-        }
-    }
-    
-    override var isHighlighted: Bool {
-        didSet {
-            if #available(iOS 13.0, *) {
-                backgroundColor = isHighlighted ?  .highlightKeyboardColor : .keyboardColor
-            } else {
-                backgroundColor = isHighlighted ?  .highlightLightKeyboard : .darkKeyboard
-            }
-        }
-    }
-    
-}
-
 @available(iOS 9.0, *)
 class DateFieldTypeView: UIScrollView {
         
-    let dateFormatter = DateFormatter()
+    private let dateFormatter = DateFormatter()
     
-    //public var fieldType: DateFieldType
-    var dateFields: [DateField] {
+    private var dateFields: [DateField] {
         get {
             var fields = [DateField]()
-            fields.append(DateField(title: "Year",
+            // some subtitles are an attempt to clarify, in case of different Locales, causing some example of patterns to look the same.
+            fields.append(DateField(type: "Year",
                                     patterns: ["YY", "YYYY"]))
-            fields.append(DateField(title: "Month",
+            fields.append(DateField(type: "Month",
                                     patterns: ["M", "MM", "MMMMM", "MMM", "MMMM"],
                                     subtitles: ["M" : "Single",
                                                 "MMMMM" : "•",
                                                 "MMM" : "• • •",
                                                 "MMMM" : "Full"]))
-            // some subtitles are an attempt to clarify, in case of different Locales, causing some example of patterns to look the same.
-            fields.append(DateField(title: "Day",
+            fields.append(DateField(type: "Day",
                                     patterns: ["d", "dd", "D"],
                                     subtitles: ["d" : "Single",
                                                 "dd" : "Of Month",
                                                 "D" : "Of Year"]))
-            fields.append(DateField(title: "Hour",
+            fields.append(DateField(type: "Hour",
                                     patterns: ["h", "hh", "H", "HH", "K", "KK", "k", "kk"],
                                     subtitles: ["h" : "Single", "hh" : "12hr",
                                                 "H" : "Single", "HH" : "24hr",
                                                 "K" : "Single", "KK" : "0-11",
                                                 "k" : "Single", "kk" : "1-24"]))
-            fields.append(DateField(title: "Minute",
+            fields.append(DateField(type: "Minute",
                                     patterns: ["m", "mm"],
                                     subtitles: ["m" : "Single"]))
-            fields.append(DateField(title: "Second",
+            fields.append(DateField(type: "Second",
                                     patterns: ["s", "ss"],
                                     subtitles: ["s" : "Single"]))
-            fields.append(DateField(title: "Day of the Week",
+            fields.append(DateField(type: "Day of the Week",
                                     patterns: ["e", "ee", "EEEEE", "EEEEEE", "E", "EEEE"],
                                     subtitles: ["e" : "Single",
                                                 "EEEEE" : "•",
                                                 "EEEEEE" : "• •",
                                                 "E" : "• • •",
                                                 "EEEE" : "Full"]))
-            fields.append(DateField(title: "Period",
+            fields.append(DateField(type: "Period",
                                     patterns: ["aaaaa", "a", "B"],
                                     subtitles: ["aaaaa" : "Single", "B" : "Text"]))
-            fields.append(DateField(title: "Week",
+            fields.append(DateField(type: "Week",
                                     patterns: ["w", "ww", "W"],
                                     subtitles: ["w" : "Single", "ww" : "Of Year", "W" : "Of Month"]))
-            fields.append(DateField(title: "Quarter",
+            fields.append(DateField(type: "Quarter",
                                     patterns: ["Q", "QQ", "QQQ", "QQQQ"]))
-            fields.append(DateField(title: "Era",
+            fields.append(DateField(type: "Era",
                                     patterns: ["GGGGG", "G", "GGGG"]))
-            fields.append(DateField(title: "Time Zone",
+            fields.append(DateField(type: "Time Zone",
                                     patterns: ["X", "Z", "ZZZZZ", "z", "O", "ZZZZ", "zzzz", "VVV", "VVVV"],
                                     subtitles: ["z" : "Abbr. / GMT",
                                                 "zzzz" : "Full",
@@ -167,7 +115,7 @@ class DateFieldTypeView: UIScrollView {
         vStack.translatesAutoresizingMaskIntoConstraints = false
         
         let textTitle = UIInsetLabel()
-        textTitle.text = field.title.uppercased()
+        textTitle.text = field.type.uppercased()
         textTitle.textColor = .gray
         textTitle.font = .boldSystemFont(ofSize: 14)
         textTitle.insets = UIEdgeInsets(top: 5, left: 5, bottom: 0, right: 0)

--- a/OpenGpxTracker/DateFieldTypeView.swift
+++ b/OpenGpxTracker/DateFieldTypeView.swift
@@ -11,6 +11,21 @@ import UIKit
 @available(iOS 9.0, *)
 class DateFieldTypeView: UIScrollView {
     
+    // MARK:- Localization Strings
+    private let kSingleDigit = NSLocalizedString("SINGLE_DIGIT", comment: "")
+    private let kFull = NSLocalizedString("FULL_TEXT", comment: "")
+    private let kText = NSLocalizedString("TEXT", comment: "")
+    
+    private let kOfMonth = NSLocalizedString("OF_MONTH", comment: "")
+    private let kOfYear = NSLocalizedString("OF_YEAR", comment: "")
+    
+    private let kAbbr = NSLocalizedString("ABBR_GMT", comment: "")
+    private let kUTCoffset = NSLocalizedString("UTC_OFFSET", comment: "")
+    private let kGMTshort = NSLocalizedString("GMT_SHORT", comment: "")
+    private let kGMTfull = NSLocalizedString("GMT_FULL", comment: "")
+    private let kLocation = NSLocalizedString("LOCATION", comment: "")
+    private let kLocationTime = NSLocalizedString("LOCATION_TIME", comment: "")
+    
     /// date formatter to display current time example
     private let dateFormatter = DateFormatter()
     
@@ -19,60 +34,60 @@ class DateFieldTypeView: UIScrollView {
         get {
             var fields = [DateField]()
             // some subtitles are an attempt to clarify, in case of different Locales, causing some example of patterns to look the same.
-            fields.append(DateField(type: "Year",
+            fields.append(DateField(type: NSLocalizedString("YEAR", comment: ""),
                                     patterns: ["YY", "YYYY"]))
-            fields.append(DateField(type: "Month",
+            fields.append(DateField(type: NSLocalizedString("MONTH", comment: ""),
                                     patterns: ["M", "MM", "MMMMM", "MMM", "MMMM"],
-                                    subtitles: ["M" : "Single",
+                                    subtitles: ["M" : kSingleDigit,
                                                 "MMMMM" : "•",
                                                 "MMM" : "• • •",
-                                                "MMMM" : "Full"]))
-            fields.append(DateField(type: "Day",
+                                                "MMMM" : kFull]))
+            fields.append(DateField(type: NSLocalizedString("DAY", comment: ""),
                                     patterns: ["d", "dd", "D"],
-                                    subtitles: ["d" : "Single",
-                                                "dd" : "Of Month",
-                                                "D" : "Of Year"]))
-            fields.append(DateField(type: "Hour",
+                                    subtitles: ["d" : kSingleDigit,
+                                                "dd" : kOfMonth,
+                                                "D" : kOfYear]))
+            fields.append(DateField(type: NSLocalizedString("HOUR", comment: ""),
                                     patterns: ["h", "hh", "H", "HH", "K", "KK", "k", "kk"],
-                                    subtitles: ["h" : "Single", "hh" : "12hr",
-                                                "H" : "Single", "HH" : "24hr",
-                                                "K" : "Single", "KK" : "0-11",
-                                                "k" : "Single", "kk" : "1-24"]))
-            fields.append(DateField(type: "Minute",
+                                    subtitles: ["h" : kSingleDigit, "hh" : "12hr",
+                                                "H" : kSingleDigit, "HH" : "24hr",
+                                                "K" : kSingleDigit, "KK" : "0-11",
+                                                "k" : kSingleDigit, "kk" : "1-24"]))
+            fields.append(DateField(type: NSLocalizedString("MINUTE", comment: ""),
                                     patterns: ["m", "mm"],
-                                    subtitles: ["m" : "Single"]))
-            fields.append(DateField(type: "Second",
+                                    subtitles: ["m" : kSingleDigit]))
+            fields.append(DateField(type: NSLocalizedString("SECOND", comment: ""),
                                     patterns: ["s", "ss"],
-                                    subtitles: ["s" : "Single"]))
-            fields.append(DateField(type: "Day of the Week",
+                                    subtitles: ["s" : kSingleDigit]))
+            fields.append(DateField(type: NSLocalizedString("DAY_OF_THE_WEEK", comment: ""),
                                     patterns: ["e", "ee", "EEEEE", "EEEEEE", "E", "EEEE"],
-                                    subtitles: ["e" : "Single",
+                                    subtitles: ["e" : kSingleDigit,
                                                 "EEEEE" : "•",
                                                 "EEEEEE" : "• •",
                                                 "E" : "• • •",
-                                                "EEEE" : "Full"]))
-            fields.append(DateField(type: "Time of Day",
+                                                "EEEE" : kFull]))
+            fields.append(DateField(type: NSLocalizedString("TIME_OF_DAY", comment: ""),
                                     patterns: ["aaaaa", "a", "B"],
-                                    subtitles: ["aaaaa" : "Single",
+                                    subtitles: ["aaaaa" : kSingleDigit,
                                                 "B" : "Text"]))
-            fields.append(DateField(type: "Week",
+            fields.append(DateField(type: NSLocalizedString("WEEK", comment: ""),
                                     patterns: ["w", "ww", "W"],
-                                    subtitles: ["w" : "Single",
-                                                "ww" : "Of Year",
-                                                "W" : "Of Month"]))
-            fields.append(DateField(type: "Quarter",
+                                    subtitles: ["w" : kSingleDigit,
+                                                "ww" : kOfYear,
+                                                "W" : kOfMonth]))
+            fields.append(DateField(type: NSLocalizedString("QUARTER", comment: ""),
                                     patterns: ["Q", "QQ", "QQQ", "QQQQ"]))
-            fields.append(DateField(type: "Era",
+            fields.append(DateField(type: NSLocalizedString("ERA", comment: ""),
                                     patterns: ["GGGGG", "G", "GGGG"]))
-            fields.append(DateField(type: "Time Zone",
+            fields.append(DateField(type: NSLocalizedString("TIME_ZONE", comment: ""),
                                     patterns: ["X", "Z", "ZZZZZ", "z", "O", "ZZZZ", "zzzz", "VVV", "VVVV"],
-                                    subtitles: ["z" : "Abbr. / GMT",
-                                                "zzzz" : "Full",
-                                                "X" : "GMT Offset",
-                                                "O" : "GMT Short",
-                                                "ZZZZ" : "GMT Full",
-                                                "VVV" : "Location",
-                                                "VVVV" : "Location's Time"]))
+                                    subtitles: ["z" : kAbbr,
+                                                "zzzz" : kFull,
+                                                "X" : kUTCoffset,
+                                                "O" : kGMTshort,
+                                                "ZZZZ" : kGMTfull,
+                                                "VVV" : kLocation,
+                                                "VVVV" : kLocationTime]))
         
             return fields
         }

--- a/OpenGpxTracker/DatePatternButton.swift
+++ b/OpenGpxTracker/DatePatternButton.swift
@@ -7,10 +7,15 @@
 
 import UIKit
 
-class DateFieldButton: UIButton {
+/// Each individual button that represents a date pattern
+class DatePatternButton: UIButton {
     
+    /// DateFormatter-friendly pattern of that the button holds.
+    ///
+    /// such as `YYYY` or `s`
     var pattern = String()
     
+    /// For dealing with button tap highlight
     override var isSelected: Bool {
         didSet {
             if #available(iOS 13.0, *) {
@@ -21,6 +26,7 @@ class DateFieldButton: UIButton {
         }
     }
     
+    /// For dealing with button tap highlight
     override var isHighlighted: Bool {
         didSet {
             if #available(iOS 13.0, *) {

--- a/OpenGpxTracker/DefaultDateFormat.swift
+++ b/OpenGpxTracker/DefaultDateFormat.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 class DefaultDateFormat {
+    
     let dateFormatter = DateFormatter()
     
-    
-    static func getDateFormat(unprocessed: String) -> String {
+    func getDateFormat(unprocessed: String) -> String {
         var newText = ""
         let arr = unprocessed.components(separatedBy: CharacterSet(charactersIn: "{}"))
         let arrCount = arr.count
@@ -25,6 +25,14 @@ class DefaultDateFormat {
         }
 
         return newText
+    }
+    
+    func getDate(processedFormat dateFormat: String, useUTC: Bool = false, useENLocale: Bool = false) -> String {
+        //processedDateFormat = DefaultDateFormat.getDateFormat(unprocessed: self.cellTextField.text!)
+        dateFormatter.dateFormat = dateFormat
+        dateFormatter.timeZone = useUTC ? TimeZone(secondsFromGMT: 0) : TimeZone.current
+        dateFormatter.locale = useENLocale ? Locale(identifier: "en_US_POSIX") : Locale.current
+        return dateFormatter.string(from: Date())
     }
 
 }

--- a/OpenGpxTracker/DefaultDateFormat.swift
+++ b/OpenGpxTracker/DefaultDateFormat.swift
@@ -7,10 +7,13 @@
 
 import Foundation
 
+/// Handles processing of 'unprocessed' user input date format, processing of sample date format, etc
 class DefaultDateFormat {
     
+    /// DateFormatter for use in each instance.
     let dateFormatter = DateFormatter()
     
+    /// returns a 'processed', `DateFormatter`-friendly date format.
     func getDateFormat(unprocessed: String) -> String {
         var newText = ""
         let arr = unprocessed.components(separatedBy: CharacterSet(charactersIn: "{}"))
@@ -27,6 +30,7 @@ class DefaultDateFormat {
         return newText
     }
     
+    /// Returns sample date time based on user input.
     func getDate(processedFormat dateFormat: String, useUTC: Bool = false, useENLocale: Bool = false) -> String {
         //processedDateFormat = DefaultDateFormat.getDateFormat(unprocessed: self.cellTextField.text!)
         dateFormatter.dateFormat = dateFormat
@@ -35,6 +39,7 @@ class DefaultDateFormat {
         return dateFormatter.string(from: Date())
     }
     
+    /// Returns Preference stored date format and its settings.
     func getDateFromPrefs() -> String {
         let dateFormat = Preferences.shared.dateFormat
         let useUTC = Preferences.shared.dateFormatUseUTC

--- a/OpenGpxTracker/DefaultDateFormat.swift
+++ b/OpenGpxTracker/DefaultDateFormat.swift
@@ -1,0 +1,30 @@
+//
+//  DefaultDateFormat.swift
+//  OpenGpxTracker
+//
+//  Created by Vincent on 4/3/20.
+//
+
+import Foundation
+
+class DefaultDateFormat {
+    let dateFormatter = DateFormatter()
+    
+    
+    static func getDateFormat(unprocessed: String) -> String {
+        var newText = ""
+        let arr = unprocessed.components(separatedBy: CharacterSet(charactersIn: "{}"))
+        let arrCount = arr.count
+        for i in 0...arrCount - 1 {
+            if arr.count == 1  {
+                newText += "'invalid'"
+            }
+            else if arrCount > 1 && !arr[i].isEmpty {
+                newText += (i % 2 == 0) ? "'\(arr[i])'" : arr[i]//arr[i]
+            }
+        }
+
+        return newText
+    }
+
+}

--- a/OpenGpxTracker/DefaultDateFormat.swift
+++ b/OpenGpxTracker/DefaultDateFormat.swift
@@ -62,19 +62,3 @@ class DefaultDateFormat {
     }
 
 }
-// from: https://stackoverflow.com/a/45073012/13292870
-// count occurances
-extension String {
-    /// stringToFind must be at least 1 character.
-    func countInstances(of stringToFind: String) -> Int {
-        assert(!stringToFind.isEmpty)
-        var count = 0
-        var searchRange: Range<String.Index>?
-        while let foundRange = range(of: stringToFind, options: [.literal], range: searchRange) {
-            count += 1
-            searchRange = Range(uncheckedBounds: (lower: foundRange.upperBound, upper: endIndex))
-        }
-        return count
-    }
-    
-}

--- a/OpenGpxTracker/DefaultDateFormat.swift
+++ b/OpenGpxTracker/DefaultDateFormat.swift
@@ -34,5 +34,13 @@ class DefaultDateFormat {
         dateFormatter.locale = useENLocale ? Locale(identifier: "en_US_POSIX") : Locale.current
         return dateFormatter.string(from: Date())
     }
+    
+    func getDateFromPrefs() -> String {
+        let dateFormat = Preferences.shared.dateFormat
+        let useUTC = Preferences.shared.dateFormatUseUTC
+        let useEN = Preferences.shared.dateFormatUseEN
+        return getDate(processedFormat: dateFormat, useUTC: useUTC, useENLocale: useEN)
+        
+    }
 
 }

--- a/OpenGpxTracker/DefaultNameSetupViewController.swift
+++ b/OpenGpxTracker/DefaultNameSetupViewController.swift
@@ -1,0 +1,123 @@
+//
+//  DefaultNameSetupViewController.swift
+//  OpenGpxTracker
+//
+//  Created by Vincent on 3/3/20.
+//
+
+import UIKit
+
+class DefaultNameSetupViewController: UITableViewController, UITextFieldDelegate {
+    
+    var cellTextField = UITextField()
+    var label = UILabel()
+
+    
+    /// Sections of table view
+    private enum kSections: Int, CaseIterable {
+        case input, presets
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
+    
+    }
+
+    func textFieldShouldClear(_ textField: UITextField) -> Bool {
+        return false
+    }
+    
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return kSections.allCases.count
+    }
+    
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        switch section {
+        case kSections.input.rawValue: return "Input"
+        case kSections.presets.rawValue: return "Presets"
+        default: fatalError("Section out of range")
+        }
+    }
+    
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        switch section {
+        case kSections.input.rawValue: return 2
+        case kSections.presets.rawValue: return 0 //placeholder
+        default: fatalError("Section out of range")
+        }
+    }
+    
+    @objc func buttonTapped(_ sender: UIBarButtonItem, for event: UIEvent) {
+        if cellTextField.text != nil {
+            switch sender.tag {
+            case 0: cellTextField.text! += "{dd}"
+            case 1: cellTextField.text! += "{MM}"
+            case 2: cellTextField.text! += "{yyyy}"
+            case 3: cellTextField.text! += "{HH}"
+            case 4: cellTextField.text! += "{mm}"
+            case 5: cellTextField.text! += "{ss}"
+            default: return
+            }
+            textFieldTyping()
+        }
+        
+    }
+
+    @objc func textFieldTyping() {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = DefaultDateFormat.getDateFormat(unprocessed: self.cellTextField.text!)
+        label.text = dateFormatter.string(from: Date())
+    }
+    
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        
+        var cell = UITableViewCell(style: .default, reuseIdentifier: "inputCell")
+        if indexPath.row == 0 {
+            
+            label = UILabel(frame: CGRect(x: 25, y: 0, width: view.frame.width - 50, height: cell.frame.height))
+            cell.addSubview(label)
+            label.text = "f"
+            //cell.textLabel!.text = dateFormatter.string(from: Date())
+        }
+        if indexPath.row == 1 {
+            cell = UITableViewCell(style: .default, reuseIdentifier: "inputCell")
+            cellTextField = UITextField(frame: CGRect(x: 25, y: 0, width: view.frame.width - 50, height: cell.frame.height))
+            //let textView = UITextView(frame: CGRect(x: 25, y: 5, width: view.frame.width - 50, height: cell.frame.height))
+            cellTextField.text = ""
+            //cellTextField.placeholder = "Default Name"
+            cellTextField.delegate = self
+            cellTextField.returnKeyType = .done
+            let bar = UIToolbar()
+            let day = UIBarButtonItem(title: "Day", style: .plain, target: self, action: #selector(buttonTapped(_:for:)))
+            day.tag = 0
+            let month = UIBarButtonItem(title: "Month", style: .plain, target: self, action: #selector(buttonTapped(_:for:)))
+            month.tag = 1
+            let year = UIBarButtonItem(title: "Year", style: .plain, target: self, action: #selector(buttonTapped(_:for:)))
+            year.tag = 2
+            let hour = UIBarButtonItem(title: "Hour", style: .plain, target: self, action: #selector(buttonTapped(_:for:)))
+            hour.tag = 3
+            let min = UIBarButtonItem(title: "Minute", style: .plain, target: self, action: #selector(buttonTapped(_:for:)))
+            min.tag = 4
+            let sec = UIBarButtonItem(title: "Second", style: .plain, target: self, action: #selector(buttonTapped(_:for:)))
+            sec.tag = 5
+
+            bar.items = [day, month, year, hour, min, sec]
+            bar.sizeToFit()
+            cellTextField.addTarget(self, action: #selector(textFieldTyping), for: UIControl.Event.editingChanged)
+            cellTextField.inputAccessoryView = bar
+
+            cell.contentView.addSubview(cellTextField)
+            if indexPath.section == kSections.input.rawValue {
+                
+            }
+        }
+        return cell
+    }
+    
+
+}

--- a/OpenGpxTracker/DefaultNameSetupViewController.swift
+++ b/OpenGpxTracker/DefaultNameSetupViewController.swift
@@ -79,10 +79,13 @@ class DefaultNameSetupViewController: UITableViewController, UITextFieldDelegate
         var cell = UITableViewCell(style: .default, reuseIdentifier: "inputCell")
         if indexPath.row == 0 {
             
-            label = UILabel(frame: CGRect(x: 25, y: 0, width: view.frame.width - 50, height: cell.frame.height))
+            label = UILabel(frame: CGRect(x: 82, y: 0, width: view.frame.width - 97, height: cell.frame.height))
             cell.addSubview(label)
-            label.text = "f"
-            //cell.textLabel!.text = dateFormatter.string(from: Date())
+            label.text = ""
+            cell.textLabel!.text = "Sample: "
+            if #available(iOS 8.2, *) {
+                cell.textLabel?.font = .systemFont(ofSize: 17, weight: .thin)
+            }
         }
         if indexPath.row == 1 {
             cell = UITableViewCell(style: .default, reuseIdentifier: "inputCell")

--- a/OpenGpxTracker/DefaultNameSetupViewController.swift
+++ b/OpenGpxTracker/DefaultNameSetupViewController.swift
@@ -49,6 +49,12 @@ class DefaultNameSetupViewController: UITableViewController, UITextFieldDelegate
             case 3: cellTextField.insertText("{HH}")
             case 4: cellTextField.insertText("{mm}")
             case 5: cellTextField.insertText("{ss}")
+            case 6:
+                cellTextField.insertText("{}")
+                
+                guard let currRange = cellTextField.selectedTextRange,
+                      let wantedRange = cellTextField.position(from: currRange.start, offset: -1) else { return }
+                cellTextField.selectedTextRange = cellTextField.textRange(from: wantedRange, to: wantedRange)
             default: return
             }
             textFieldTyping()
@@ -92,12 +98,12 @@ class DefaultNameSetupViewController: UITableViewController, UITextFieldDelegate
     }
 
     func textFieldShouldClear(_ textField: UITextField) -> Bool {
-        return false
+        return true
     }
     
     func saveDateFormat(_ dateFormat: String, input: String?, index: Int = -1) {
         guard let input = input else { return }
-        if dateFormat == "invalid" || input.isEmpty { return } // ensures no invalid date format (revert)
+        if dateFormat == "invalid" || input.isEmpty || dateFormat.isEmpty { return } // ensures no invalid date format (revert)
         preferences.dateFormat = dateFormat
         preferences.dateFormatInput = input
         preferences.dateFormatPreset = index
@@ -168,24 +174,26 @@ class DefaultNameSetupViewController: UITableViewController, UITextFieldDelegate
                 //let textView = UITextView(frame: CGRect(x: 25, y: 5, width: view.frame.width - 50, height: cell.frame.height))
                 cellTextField.text = preferences.dateFormatInput
                 textFieldTyping()
-                //cellTextField.placeholder = "Default Name"
+                cellTextField.clearButtonMode = .whileEditing
                 cellTextField.delegate = self
                 cellTextField.returnKeyType = .done
                 let bar = UIToolbar()
+                let bracket = UIBarButtonItem(title: "{ ... }", style: .plain, target: self, action: #selector(buttonTapped(_:for:)))
+                bracket.tag = 6
                 let day = UIBarButtonItem(title: "Day", style: .plain, target: self, action: #selector(buttonTapped(_:for:)))
                 day.tag = 0
                 let month = UIBarButtonItem(title: "Month", style: .plain, target: self, action: #selector(buttonTapped(_:for:)))
                 month.tag = 1
                 let year = UIBarButtonItem(title: "Year", style: .plain, target: self, action: #selector(buttonTapped(_:for:)))
                 year.tag = 2
-                let hour = UIBarButtonItem(title: "Hour", style: .plain, target: self, action: #selector(buttonTapped(_:for:)))
+                let hour = UIBarButtonItem(title: "Hr", style: .plain, target: self, action: #selector(buttonTapped(_:for:)))
                 hour.tag = 3
-                let min = UIBarButtonItem(title: "Minute", style: .plain, target: self, action: #selector(buttonTapped(_:for:)))
+                let min = UIBarButtonItem(title: "Min", style: .plain, target: self, action: #selector(buttonTapped(_:for:)))
                 min.tag = 4
-                let sec = UIBarButtonItem(title: "Second", style: .plain, target: self, action: #selector(buttonTapped(_:for:)))
+                let sec = UIBarButtonItem(title: "Sec", style: .plain, target: self, action: #selector(buttonTapped(_:for:)))
                 sec.tag = 5
 
-                bar.items = [day, month, year, hour, min, sec]
+                bar.items = [bracket, day, month, year, hour, min, sec]
                 bar.sizeToFit()
                 cellTextField.addTarget(self, action: #selector(textFieldTyping), for: UIControl.Event.editingChanged)
                 cellTextField.inputAccessoryView = bar

--- a/OpenGpxTracker/DefaultNameSetupViewController.swift
+++ b/OpenGpxTracker/DefaultNameSetupViewController.swift
@@ -136,7 +136,7 @@ class DefaultNameSetupViewController: UITableViewController, UITextFieldDelegate
     
     override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         if section == kSections.input.rawValue {
-            return "Clicking done on the keyboard saves the date format for use, regardless if its a preset or custom."
+            return "Clicking done on the keyboard saves the date format for use, regardless if its a preset or custom. Date format should be encapsulated within { ... }. For full list of applicable date format syntax please refer to Unicode Technical Standard (UTS) #35."
         }
         else { return nil }
     }

--- a/OpenGpxTracker/DefaultNameSetupViewController.swift
+++ b/OpenGpxTracker/DefaultNameSetupViewController.swift
@@ -249,7 +249,7 @@ class DefaultNameSetupViewController: UITableViewController, UITextFieldDelegate
                 bar.items = [bracket, day, month, year, hour, min, sec]
                 bar.sizeToFit()
                 
-                if #available(iOS 13, *) {
+                if #available(iOS 9, *) {
                     let dateFieldSelector = DateFieldTypeView(frame: CGRect(x: 0, y: 0, width: cellTextField.frame.width, height: 75))
                     cellTextField.inputAccessoryView = dateFieldSelector
                 }

--- a/OpenGpxTracker/DefaultNameSetupViewController.swift
+++ b/OpenGpxTracker/DefaultNameSetupViewController.swift
@@ -21,7 +21,7 @@ class DefaultNameSetupViewController: UITableViewController, UITextFieldDelegate
     /// Global Preferences
     var preferences : Preferences = Preferences.shared
 
-    let presets = [("Defaults", "dd-MMM-yyyy-HHmm", "{dd}-{MMM}-{yyyy}-{HH}{mm}"),
+    let presets =  [("Defaults", "dd-MMM-yyyy-HHmm", "{dd}-{MMM}-{yyyy}-{HH}{mm}"),
                     ("ISO8601 (UTC)", "yyyy-MM-dd'T'HH:mm:ss'Z'", "{yyyy}-{MM}-{dd}T{HH}:{mm}:{ss}Z"),
                     ("ISO8601 (UTC offset)", "yyyy-MM-dd'T'HH:mm:ssZ", "{yyyy}-{MM}-{dd}T{HH}:{mm}:{ss}{Z}"),
                     ("Day, Date at time (12 hr)", "EEEE, MMM d, yyyy 'at' h:mm a", "{EEEE}, {MMM} {d}, {yyyy} at {h}:{mm} {a}"),

--- a/OpenGpxTracker/DefaultNameSetupViewController.swift
+++ b/OpenGpxTracker/DefaultNameSetupViewController.swift
@@ -29,7 +29,7 @@ class DefaultNameSetupViewController: UITableViewController, UITextFieldDelegate
     
     /// Sections of table view
     private enum kSections: Int, CaseIterable {
-        case input, useUTC, presets
+        case input, settings, presets
     }
 
     override func viewDidLoad() {
@@ -111,12 +111,13 @@ class DefaultNameSetupViewController: UITableViewController, UITextFieldDelegate
     }
     
     func lockUTCCell(_ state: Bool) {
-        let indexPath = IndexPath(row: 0, section: kSections.useUTC.rawValue)
+        let indexPath = IndexPath(row: 0, section: kSections.settings.rawValue)
         useUTC = state
         
         tableView.cellForRow(at: indexPath)?.accessoryType = state ? .checkmark : .none
         tableView.cellForRow(at: indexPath)?.isUserInteractionEnabled = !state
         tableView.cellForRow(at: indexPath)?.textLabel?.isEnabled = !state
+        textFieldTyping()
     }
     
     // MARK:- Table View
@@ -127,16 +128,16 @@ class DefaultNameSetupViewController: UITableViewController, UITextFieldDelegate
     
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         switch section {
-        case kSections.input.rawValue: return "Date Format"
-        case kSections.useUTC.rawValue: return "Time/Locale Settings"
-        case kSections.presets.rawValue: return "Presets"
+        case kSections.input.rawValue: return NSLocalizedString("DEFAULT_NAME_DATE_FORMAT", comment: "no comment")
+        case kSections.settings.rawValue: return NSLocalizedString("DEFAULT_NAME_SETTINGS", comment: "no comment")
+        case kSections.presets.rawValue: return NSLocalizedString("DEFAULT_NAME_PRESET", comment: "no comment")
         default: fatalError("Section out of range")
         }
     }
     
     override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         if section == kSections.input.rawValue {
-            return "Clicking done on the keyboard saves the date format for use, regardless if its a preset or custom. Date format should be encapsulated within { ... }. For full list of applicable date format syntax please refer to Unicode Technical Standard (UTS) #35."
+            return NSLocalizedString("DEFAULT_NAME_INPUT_FOOTER", comment: "no comment")
         }
         else { return nil }
     }
@@ -144,7 +145,7 @@ class DefaultNameSetupViewController: UITableViewController, UITextFieldDelegate
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch section {
         case kSections.input.rawValue: return 2
-        case kSections.useUTC.rawValue:
+        case kSections.settings.rawValue:
             if Locale.current.languageCode == "en" {
                 return 1 // force locale to EN should only be shown if Locale is not EN.
             }
@@ -165,7 +166,8 @@ class DefaultNameSetupViewController: UITableViewController, UITextFieldDelegate
                 cellSampleLabel.font = .boldSystemFont(ofSize: 17)
                 cell.addSubview(cellSampleLabel)
                 cellSampleLabel.text = ""
-                cell.textLabel!.text = "Sample: "
+                cellSampleLabel.adjustsFontSizeToFitWidth = true
+                cell.textLabel!.text = NSLocalizedString("DEFAULT_NAME_SAMPLE_OUTPUT_TITLE", comment: "no comment")
                 cell.textLabel?.font = .systemFont(ofSize: 17)
                 
             }
@@ -207,9 +209,9 @@ class DefaultNameSetupViewController: UITableViewController, UITextFieldDelegate
             cellTextField.autocorrectionType = .no
         }
             
-        else if indexPath.section == kSections.useUTC.rawValue {
+        else if indexPath.section == kSections.settings.rawValue {
             if indexPath.row == 0 {
-                cell.textLabel!.text = "Use UTC?"
+                cell.textLabel!.text = NSLocalizedString("DEFAULT_NAME_USE_UTC", comment: "no comment")//"Use UTC?"
                 cell.accessoryType = preferences.dateFormatUseUTC ? .checkmark : .none
                 
                 if preferences.dateFormatPreset == 1 {
@@ -218,7 +220,7 @@ class DefaultNameSetupViewController: UITableViewController, UITextFieldDelegate
                 }
             }
             else if indexPath.row == 1 {
-                cell.textLabel!.text = "Force English Locale?"
+                cell.textLabel!.text = NSLocalizedString("DEFAULT_NAME_ENGLISH_LOCALE", comment: "no comment")//"Force English Locale?"
                 cell.accessoryType = preferences.dateFormatUseEN ? .checkmark : .none
             }
         }
@@ -236,7 +238,7 @@ class DefaultNameSetupViewController: UITableViewController, UITextFieldDelegate
         return cell
     }
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        if indexPath.section == kSections.useUTC.rawValue {
+        if indexPath.section == kSections.settings.rawValue {
             if indexPath.row == 0 {
                 //remove checkmark from selected utc setting
                 let newUseUTC = !preferences.dateFormatUseUTC

--- a/OpenGpxTracker/DefaultNameSetupViewController.swift
+++ b/OpenGpxTracker/DefaultNameSetupViewController.swift
@@ -278,10 +278,12 @@ class DefaultNameSetupViewController: UITableViewController, UITextFieldDelegate
                     cell.isUserInteractionEnabled = !useUTC
                     cell.textLabel?.isEnabled = !useUTC
                 }
+                textFieldTyping()
             }
             else if indexPath.row == 1 {
                 cell.textLabel!.text = NSLocalizedString("DEFAULT_NAME_ENGLISH_LOCALE", comment: "no comment")//"Force English Locale?"
                 cell.accessoryType = preferences.dateFormatUseEN ? .checkmark : .none
+                textFieldTyping()
             }
         }
         

--- a/OpenGpxTracker/DefaultNameSetupViewController.swift
+++ b/OpenGpxTracker/DefaultNameSetupViewController.swift
@@ -55,12 +55,12 @@ class DefaultNameSetupViewController: UITableViewController, UITextFieldDelegate
     @objc func buttonTapped(_ sender: UIBarButtonItem, for event: UIEvent) {
         if cellTextField.text != nil {
             switch sender.tag {
-            case 0: cellTextField.text! += "{dd}"
-            case 1: cellTextField.text! += "{MM}"
-            case 2: cellTextField.text! += "{yyyy}"
-            case 3: cellTextField.text! += "{HH}"
-            case 4: cellTextField.text! += "{mm}"
-            case 5: cellTextField.text! += "{ss}"
+            case 0: cellTextField.insertText("{dd}")
+            case 1: cellTextField.insertText("{MM}")
+            case 2: cellTextField.insertText("{yyyy}")
+            case 3: cellTextField.insertText("{HH}")
+            case 4: cellTextField.insertText("{mm}")
+            case 5: cellTextField.insertText("{ss}")
             default: return
             }
             textFieldTyping()
@@ -76,7 +76,7 @@ class DefaultNameSetupViewController: UITableViewController, UITextFieldDelegate
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         
-        var cell = UITableViewCell(style: .default, reuseIdentifier: "inputCell")
+        let cell = UITableViewCell(style: .default, reuseIdentifier: "inputCell")
         if indexPath.row == 0 {
             
             label = UILabel(frame: CGRect(x: 82, y: 0, width: view.frame.width - 97, height: cell.frame.height))
@@ -88,7 +88,6 @@ class DefaultNameSetupViewController: UITableViewController, UITextFieldDelegate
             }
         }
         if indexPath.row == 1 {
-            cell = UITableViewCell(style: .default, reuseIdentifier: "inputCell")
             cellTextField = UITextField(frame: CGRect(x: 25, y: 0, width: view.frame.width - 50, height: cell.frame.height))
             //let textView = UITextView(frame: CGRect(x: 25, y: 5, width: view.frame.width - 50, height: cell.frame.height))
             cellTextField.text = ""

--- a/OpenGpxTracker/DefaultNameSetupViewController.swift
+++ b/OpenGpxTracker/DefaultNameSetupViewController.swift
@@ -217,6 +217,7 @@ class DefaultNameSetupViewController: UITableViewController, UITextFieldDelegate
                 cellSampleLabel.font = .boldSystemFont(ofSize: 17)
                 cell.addSubview(cellSampleLabel)
                 cellSampleLabel.text = ""
+                textFieldTyping()
                 cellSampleLabel.adjustsFontSizeToFitWidth = true
                 cell.textLabel!.text = NSLocalizedString("DEFAULT_NAME_SAMPLE_OUTPUT_TITLE", comment: "no comment")
                 cell.textLabel?.font = .systemFont(ofSize: 17)

--- a/OpenGpxTracker/DefaultNameSetupViewController.swift
+++ b/OpenGpxTracker/DefaultNameSetupViewController.swift
@@ -90,12 +90,12 @@ class DefaultNameSetupViewController: UITableViewController, UITextFieldDelegate
                 cellTextField.selectedTextRange = cellTextField.textRange(from: wantedRange, to: wantedRange)
             default: return
             }
-            textFieldTyping()
+            updateSampleTextField()
         }
     }
 
     /// Call when text field is currently editing, and an update to sample label is required.
-    @objc func textFieldTyping() {
+    @objc func updateSampleTextField() {
         processedDateFormat = defaultDateFormat.getDateFormat(unprocessed: self.cellTextField.text!)
         //dateFormatter.dateFormat = processedDateFormat
         cellSampleLabel.text = defaultDateFormat.getDate(processedFormat: processedDateFormat, useUTC: useUTC, useENLocale: useEN)
@@ -165,7 +165,7 @@ class DefaultNameSetupViewController: UITableViewController, UITextFieldDelegate
         tableView.cellForRow(at: indexPath)?.accessoryType = state ? .checkmark : .none
         tableView.cellForRow(at: indexPath)?.isUserInteractionEnabled = !state
         tableView.cellForRow(at: indexPath)?.textLabel?.isEnabled = !state
-        textFieldTyping()
+        updateSampleTextField()
     }
     
     /// return number of sections based on `kSections`
@@ -217,7 +217,7 @@ class DefaultNameSetupViewController: UITableViewController, UITextFieldDelegate
                 cellSampleLabel.font = .boldSystemFont(ofSize: 17)
                 cell.addSubview(cellSampleLabel)
                 cellSampleLabel.text = ""
-                textFieldTyping()
+                updateSampleTextField()
                 cellSampleLabel.adjustsFontSizeToFitWidth = true
                 cell.textLabel!.text = NSLocalizedString("DEFAULT_NAME_SAMPLE_OUTPUT_TITLE", comment: "no comment")
                 cell.textLabel?.font = .systemFont(ofSize: 17)
@@ -227,7 +227,7 @@ class DefaultNameSetupViewController: UITableViewController, UITextFieldDelegate
                 cellTextField = UITextField(frame: CGRect(x: 22, y: 0, width: view.frame.width - 48, height: cell.frame.height))
                 //let textView = UITextView(frame: CGRect(x: 25, y: 5, width: view.frame.width - 50, height: cell.frame.height))
                 cellTextField.text = preferences.dateFormatInput
-                textFieldTyping()
+                updateSampleTextField()
                 cellTextField.clearButtonMode = .whileEditing
                 cellTextField.delegate = self
                 cellTextField.returnKeyType = .done
@@ -257,7 +257,7 @@ class DefaultNameSetupViewController: UITableViewController, UITextFieldDelegate
                 else {
                     cellTextField.inputAccessoryView = bar
                 }
-                cellTextField.addTarget(self, action: #selector(textFieldTyping), for: UIControl.Event.editingChanged)
+                cellTextField.addTarget(self, action: #selector(updateSampleTextField), for: UIControl.Event.editingChanged)
 
 
                 cell.contentView.addSubview(cellTextField)
@@ -278,12 +278,12 @@ class DefaultNameSetupViewController: UITableViewController, UITextFieldDelegate
                     cell.isUserInteractionEnabled = !useUTC
                     cell.textLabel?.isEnabled = !useUTC
                 }
-                textFieldTyping()
+                updateSampleTextField()
             }
             else if indexPath.row == 1 {
                 cell.textLabel!.text = NSLocalizedString("DEFAULT_NAME_ENGLISH_LOCALE", comment: "no comment")//"Force English Locale?"
                 cell.accessoryType = preferences.dateFormatUseEN ? .checkmark : .none
-                textFieldTyping()
+                updateSampleTextField()
             }
         }
         
@@ -317,7 +317,7 @@ class DefaultNameSetupViewController: UITableViewController, UITextFieldDelegate
                 useEN = newUseEN
                 tableView.cellForRow(at: indexPath)?.accessoryType = newUseEN ? .checkmark : .none
             }
-            textFieldTyping()
+            updateSampleTextField()
         }
         if indexPath.section == kSections.presets.rawValue {
             //cellSampleLabel.text = "{\(presets[indexPath.row].1)}"
@@ -332,7 +332,7 @@ class DefaultNameSetupViewController: UITableViewController, UITextFieldDelegate
             tableView.cellForRow(at: indexPath)?.accessoryType = .checkmark
             preferences.dateFormatPreset = indexPath.row
             preferences.dateFormatInput = presets[indexPath.row].2
-            textFieldTyping()
+            updateSampleTextField()
             preferences.dateFormat = processedDateFormat
             if preferences.dateFormatPreset == 1 {
                 lockUTCCell(true)

--- a/OpenGpxTracker/Preferences.swift
+++ b/OpenGpxTracker/Preferences.swift
@@ -24,6 +24,17 @@ let kDefaultsKeyUseImperial: String = "UseImperial"
 /// Key on Defaults for the current selected activity type.
 let kDefaultsKeyActivityType: String = "ActivityType"
 
+/// Key on Defaults for the current date format..
+let kDefaultsKeyDateFormat: String = "DateFormat"
+
+/// Key on Defaults for the current input date format
+let kDefaultsKeyDateFormatInput: String = "DateFormatPresetInput"
+
+/// Key on Defaults for the current selected date format preset cell index.
+let kDefaultsKeyDateFormatPreset: String = "DateFormatPreset"
+
+/// Key on Defaults for the current selected date format, to use UTC time or not..
+let kDefaultsKeyDateFormatUseUTC: String = "DateFormatPresetUseUTC"
 
 /// A class to handle app preferences in one single place.
 /// When the app starts for the first time the following preferences are set:
@@ -52,6 +63,18 @@ class Preferences: NSObject {
     
     /// In memory value of the preference.
     private var _activityType: CLActivityType = .other
+    
+    ///
+    private var _dateFormat = "dd-MMM-yyyy-HHmm"
+    
+    ///
+    private var _dateFormatInput = "{dd}-{MMM}-{yyyy}-{HH}{mm}"
+    
+    ///
+    private var _dateFormatPreset: Int = 0
+    
+    ///
+    private var _dateFormatUseUTC: Bool = false
     
     /// UserDefaults.standard shortcut
     private let defaults = UserDefaults.standard
@@ -88,6 +111,30 @@ class Preferences: NSObject {
         if let activityTypeInt = defaults.object(forKey: kDefaultsKeyActivityType) as? Int {
             _activityType = CLActivityType(rawValue: activityTypeInt)!
             print("** Preferences:: loaded preference from defaults activityTypeInt \(activityTypeInt)")
+        }
+        
+        // load previous date format
+        if let dateFormatStr = defaults.object(forKey: kDefaultsKeyDateFormat) as? String {
+            _dateFormat = dateFormatStr
+            print("** Preferences:: loaded preference from defaults dateFormatStr \(dateFormatStr)")
+        }
+        
+        // load previous date format (usr input)
+        if let dateFormatStrIn = defaults.object(forKey: kDefaultsKeyDateFormatInput) as? String {
+            _dateFormatInput = dateFormatStrIn
+            print("** Preferences:: loaded preference from defaults dateFormatStr \(dateFormatStrIn)")
+        }
+        
+        // load previous date format preset
+        if let dateFormatPresetInt = defaults.object(forKey: kDefaultsKeyDateFormatPreset) as? Int {
+            _dateFormatPreset = dateFormatPresetInt
+            print("** Preferences:: loaded preference from defaults dateFormatPresetInt \(dateFormatPresetInt)")
+        }
+        
+        // load previous date format, to use UTC time instead of local time
+        if let dateFormatUTCBool = defaults.object(forKey: kDefaultsKeyDateFormatPreset) as? Bool {
+            _dateFormatUseUTC = dateFormatUTCBool
+            print("** Preferences:: loaded preference from defaults dateFormatPresetUTCBool \(dateFormatUTCBool)")
         }
     }
     
@@ -156,6 +203,52 @@ class Preferences: NSObject {
         set {
             _activityType = CLActivityType(rawValue: newValue)!
             defaults.set(newValue, forKey: kDefaultsKeyActivityType)
+        }
+    }
+    
+    /// Gets and sets the date formatter friendly date format
+    var dateFormat: String {
+        get {
+            return _dateFormat
+        }
+        
+        set {
+             _dateFormat = newValue
+             defaults.set(newValue, forKey: kDefaultsKeyDateFormat)
+        }
+    }
+    
+    /// Gets and sets the user friendly input date format
+    var dateFormatInput: String {
+        get {
+            return _dateFormatInput
+        }
+        
+        set {
+             _dateFormatInput = newValue
+             defaults.set(newValue, forKey: kDefaultsKeyDateFormatInput)
+        }
+    }
+    
+    /// Get and sets user preference of date format presets. (-1 if custom)
+    var dateFormatPreset: Int {
+        get {
+            return _dateFormatPreset
+        }
+        set {
+            _dateFormatPreset = newValue
+             defaults.set(newValue, forKey: kDefaultsKeyDateFormatPreset)
+        }
+    }
+    
+    /// Get and sets whether to use UTC for date format
+    var dateFormatUseUTC: Bool {
+        get {
+            return _dateFormatUseUTC
+        }
+        set {
+            _dateFormatUseUTC = newValue
+             defaults.set(newValue, forKey: kDefaultsKeyDateFormatUseUTC)
         }
     }
 }

--- a/OpenGpxTracker/Preferences.swift
+++ b/OpenGpxTracker/Preferences.swift
@@ -253,6 +253,14 @@ class Preferences: NSObject {
         }
     }
     
+    /// Get date format preset name
+    var dateFormatPresetName: String {
+        get {
+            let presets =  ["Defaults", "ISO8601 (UTC)", "ISO8601 (UTC offset)", "Day, Date at time (12 hr)", "Day, Date at time (24 hr)"]
+            return presets[_dateFormatPreset]
+        }
+    }
+    
     /// Get and sets whether to use UTC for date format
     var dateFormatUseUTC: Bool {
         get {

--- a/OpenGpxTracker/Preferences.swift
+++ b/OpenGpxTracker/Preferences.swift
@@ -36,6 +36,9 @@ let kDefaultsKeyDateFormatPreset: String = "DateFormatPreset"
 /// Key on Defaults for the current selected date format, to use UTC time or not..
 let kDefaultsKeyDateFormatUseUTC: String = "DateFormatPresetUseUTC"
 
+/// Key on Defaults for the current selected date format, to use local Locale or `en_US_POSIX`
+let kDefaultsKeyDateFormatUseEN: String = "DateFormatPresetUseEN"
+
 /// A class to handle app preferences in one single place.
 /// When the app starts for the first time the following preferences are set:
 ///
@@ -75,6 +78,9 @@ class Preferences: NSObject {
     
     ///
     private var _dateFormatUseUTC: Bool = false
+    
+    ///
+    private var _dateFormatUseEN: Bool = false
     
     /// UserDefaults.standard shortcut
     private let defaults = UserDefaults.standard
@@ -122,7 +128,7 @@ class Preferences: NSObject {
         // load previous date format (usr input)
         if let dateFormatStrIn = defaults.object(forKey: kDefaultsKeyDateFormatInput) as? String {
             _dateFormatInput = dateFormatStrIn
-            print("** Preferences:: loaded preference from defaults dateFormatStr \(dateFormatStrIn)")
+            print("** Preferences:: loaded preference from defaults dateFormatStrIn \(dateFormatStrIn)")
         }
         
         // load previous date format preset
@@ -132,9 +138,15 @@ class Preferences: NSObject {
         }
         
         // load previous date format, to use UTC time instead of local time
-        if let dateFormatUTCBool = defaults.object(forKey: kDefaultsKeyDateFormatPreset) as? Bool {
+        if let dateFormatUTCBool = defaults.object(forKey: kDefaultsKeyDateFormatUseUTC) as? Bool {
             _dateFormatUseUTC = dateFormatUTCBool
             print("** Preferences:: loaded preference from defaults dateFormatPresetUTCBool \(dateFormatUTCBool)")
+        }
+        
+        // load previous date format, to use EN locale instead of local locale
+        if let dateFormatENBool = defaults.object(forKey: kDefaultsKeyDateFormatUseEN) as? Bool {
+            _dateFormatUseEN = dateFormatENBool
+            print("** Preferences:: loaded preference from defaults dateFormatPresetENBool \(dateFormatENBool)")
         }
     }
     
@@ -249,6 +261,17 @@ class Preferences: NSObject {
         set {
             _dateFormatUseUTC = newValue
              defaults.set(newValue, forKey: kDefaultsKeyDateFormatUseUTC)
+        }
+    }
+    
+    /// Get and sets whether to use local locale or EN
+    var dateFormatUseEN: Bool {
+        get {
+            return _dateFormatUseEN
+        }
+        set {
+            _dateFormatUseEN = newValue
+             defaults.set(newValue, forKey: kDefaultsKeyDateFormatUseEN)
         }
     }
 }

--- a/OpenGpxTracker/Preferences.swift
+++ b/OpenGpxTracker/Preferences.swift
@@ -257,7 +257,7 @@ class Preferences: NSObject {
     var dateFormatPresetName: String {
         get {
             let presets =  ["Defaults", "ISO8601 (UTC)", "ISO8601 (UTC offset)", "Day, Date at time (12 hr)", "Day, Date at time (24 hr)"]
-            return presets[_dateFormatPreset]
+            return _dateFormatPreset < presets.count ? presets[_dateFormatPreset] : "???"
         }
     }
     

--- a/OpenGpxTracker/PreferencesTableViewController.swift
+++ b/OpenGpxTracker/PreferencesTableViewController.swift
@@ -54,6 +54,8 @@ class PreferencesTableViewController: UITableViewController, UINavigationBarDele
     
     var cache : MapCache = MapCache(withConfig: MapCacheConfig(withUrlTemplate: ""))
     
+    // Compute once, better performance for scrolling table view (reuse)
+    /// Store cached size for reuse.
     var cachedSize = String()
     
     /// Does the following:

--- a/OpenGpxTracker/PreferencesTableViewController.swift
+++ b/OpenGpxTracker/PreferencesTableViewController.swift
@@ -54,6 +54,8 @@ class PreferencesTableViewController: UITableViewController, UINavigationBarDele
     
     var cache : MapCache = MapCache(withConfig: MapCacheConfig(withUrlTemplate: ""))
     
+    var cachedSize = String()
+    
     /// Does the following:
     /// 1. Defines the areas for navBar and the Table view
     /// 2. Sets the title
@@ -68,6 +70,9 @@ class PreferencesTableViewController: UITableViewController, UINavigationBarDele
         self.title = NSLocalizedString("PREFERENCES", comment: "no comment")
         let shareItem = UIBarButtonItem(title: NSLocalizedString("DONE", comment: "no comment"), style: UIBarButtonItem.Style.plain, target: self, action: #selector(PreferencesTableViewController.closePreferencesTableViewController))
         self.navigationItem.rightBarButtonItems = [shareItem]
+        
+        let fileSize = cache.diskCache.fileSize ?? 0
+        cachedSize = Int(fileSize).asFileSize()
     }
     
     /// Close this controller.
@@ -158,8 +163,8 @@ class PreferencesTableViewController: UITableViewController, UINavigationBarDele
             case kUseOfflineCacheCell:
                 cell = UITableViewCell(style: .subtitle, reuseIdentifier: "CacheCell")
                 cell.textLabel?.text = NSLocalizedString("OFFLINE_CACHE", comment: "no comment")
-                let fileSize = cache.diskCache.fileSize ?? 0
-                cell.detailTextLabel?.text = Int(fileSize).asFileSize()
+                
+                cell.detailTextLabel?.text = cachedSize
                 if preferences.useCache {
                     cell.accessoryType = .checkmark
                 }
@@ -258,7 +263,8 @@ class PreferencesTableViewController: UITableViewController, UINavigationBarDele
                     cell.textLabel?.textColor = UIColor.gray
                     //Clear the size text
                     let cell2 = tableView.cellForRow(at: IndexPath(row: kUseOfflineCacheCell, section: kCacheSection))
-                    cell2?.detailTextLabel?.text = 0.asFileSize()
+                    self.cachedSize = 0.asFileSize()
+                    cell2?.detailTextLabel?.text = self.cachedSize
                 }
             default:
                 fatalError("didSelectRowAt: Unknown cell")

--- a/OpenGpxTracker/PreferencesTableViewController.swift
+++ b/OpenGpxTracker/PreferencesTableViewController.swift
@@ -202,10 +202,11 @@ class PreferencesTableViewController: UITableViewController, UINavigationBarDele
         
         // Default Name section
         if indexPath.section == kDefaultNameSection {
+            let dateFormatter = DefaultDateFormat()
             cell = UITableViewCell(style: .subtitle, reuseIdentifier: "DefaultNameCell")
-            cell.textLabel?.text = "Set to:"
-            cell.detailTextLabel?.text = preferences.dateFormatPreset == -1 ?
-                                         preferences.dateFormatInput : preferences.dateFormatPresetName
+            cell.textLabel?.text = preferences.dateFormatPreset == -1 ? preferences.dateFormatInput : preferences.dateFormatPresetName
+            let dateText = dateFormatter.getDate(processedFormat: preferences.dateFormat, useUTC: preferences.dateFormatUseUTC, useENLocale: preferences.dateFormatUseEN)
+            cell.detailTextLabel?.text = dateText
             cell.accessoryType = .disclosureIndicator
         }
         

--- a/OpenGpxTracker/PreferencesTableViewController.swift
+++ b/OpenGpxTracker/PreferencesTableViewController.swift
@@ -24,6 +24,9 @@ let kMapSourceSection = 2
 /// Activity Type Section Id in PreferencesTableViewController
 let kActivityTypeSection = 3
 
+/// Default Name Section Id in PreferencesTableViewController
+let kDefaultNameSection = 4
+
 /// Cell Id of the Use Imperial units in UnitsSection
 let kUseImperialUnitsCell = 0
 
@@ -90,7 +93,7 @@ class PreferencesTableViewController: UITableViewController, UINavigationBarDele
     /// Returns 4 sections: Units, Cache, Map Source, Activity Type
     override func numberOfSections(in tableView: UITableView?) -> Int {
         // Return the number of sections.
-        return 4
+        return 5
     }
     
     /// Returns the title of the existing sections.
@@ -102,6 +105,7 @@ class PreferencesTableViewController: UITableViewController, UINavigationBarDele
         case kCacheSection: return NSLocalizedString("CACHE", comment: "no comment")
         case kMapSourceSection: return NSLocalizedString("MAP_SOURCE", comment: "no comment")
         case kActivityTypeSection: return NSLocalizedString("ACTIVITY_TYPE", comment: "no comment")
+        case kDefaultNameSection: return NSLocalizedString("DEFAULT_NAME_SECTION", comment: "no comment")
         default: fatalError("Unknown section")
         }
     }
@@ -115,6 +119,7 @@ class PreferencesTableViewController: UITableViewController, UINavigationBarDele
         case kUnitsSection: return 1
         case kMapSourceSection: return GPXTileServer.count
         case kActivityTypeSection: return CLActivityType.count
+        case kDefaultNameSection: return 1
         default: fatalError("Unknown section")
         }
     }
@@ -186,6 +191,14 @@ class PreferencesTableViewController: UITableViewController, UINavigationBarDele
             if indexPath.row + 1 == preferences.locationActivityTypeInt {
                 cell.accessoryType = .checkmark
             }
+        }
+        
+        // Default Name section
+        if indexPath.section == kDefaultNameSection {
+            cell = UITableViewCell(style: .value1, reuseIdentifier: "DefaultNameCell")
+            cell.textLabel?.text = "Set to:"
+            cell.detailTextLabel?.text = "DD-MM-HH" //placeholder
+            cell.accessoryType = .disclosureIndicator
         }
         
         return cell
@@ -278,6 +291,11 @@ class PreferencesTableViewController: UITableViewController, UINavigationBarDele
             preferences.locationActivityTypeInt = indexPath.row + 1 // +1 as activityType raw value starts at index 1
             
             self.delegate?.didUpdateActivityType((indexPath as NSIndexPath).row + 1)
+        }
+        
+        if indexPath.section == kDefaultNameSection {
+            print("PreferencesTableView Default Name cell clicked")
+            self.navigationController?.pushViewController(DefaultNameSetupViewController(style: .grouped), animated: true)
         }
         
         //unselect row

--- a/OpenGpxTracker/PreferencesTableViewController.swift
+++ b/OpenGpxTracker/PreferencesTableViewController.swift
@@ -202,9 +202,10 @@ class PreferencesTableViewController: UITableViewController, UINavigationBarDele
         
         // Default Name section
         if indexPath.section == kDefaultNameSection {
-            cell = UITableViewCell(style: .value1, reuseIdentifier: "DefaultNameCell")
+            cell = UITableViewCell(style: .subtitle, reuseIdentifier: "DefaultNameCell")
             cell.textLabel?.text = "Set to:"
-            cell.detailTextLabel?.text = "DD-MM-HH" //placeholder
+            cell.detailTextLabel?.text = preferences.dateFormatPreset == -1 ?
+                                         preferences.dateFormatInput : preferences.dateFormatPresetName
             cell.accessoryType = .disclosureIndicator
         }
         

--- a/OpenGpxTracker/String+CountInstances.swift
+++ b/OpenGpxTracker/String+CountInstances.swift
@@ -1,0 +1,25 @@
+//
+//  String+CountInstances.swift
+//  OpenGpxTracker
+//
+//  Created by Vincent Neo on 17/4/20.
+//
+
+import Foundation
+
+/// from: https://stackoverflow.com/a/45073012/13292870
+/// count occurances
+extension String {
+    /// counts number of instances of stringToFind; must be of at least 1 character.
+    func countInstances(of stringToFind: String) -> Int {
+        assert(!stringToFind.isEmpty)
+        var count = 0
+        var searchRange: Range<String.Index>?
+        while let foundRange = range(of: stringToFind, options: [.literal], range: searchRange) {
+            count += 1
+            searchRange = Range(uncheckedBounds: (lower: foundRange.upperBound, upper: endIndex))
+        }
+        return count
+    }
+    
+}

--- a/OpenGpxTracker/UIColor+DarkMode.swift
+++ b/OpenGpxTracker/UIColor+DarkMode.swift
@@ -46,11 +46,3 @@ extension UIColor {
     }
     
 }
-
-extension UIColor {
-    static let lightKeyboard = UIColor(red: 209/255, green: 213/255, blue: 219/255, alpha: 1.00)
-    static let darkKeyboard = UIColor(red: 36/255, green: 36/255, blue: 36/255, alpha: 1.00)
-    
-    static let highlightLightKeyboard = UIColor(red: 229/255, green: 233/255, blue: 239/255, alpha: 1.00)
-    static let highlightDarkKeyboard = UIColor(red: 56/255, green: 56/255, blue: 56/255, alpha: 1.00)
-}

--- a/OpenGpxTracker/UIColor+DarkMode.swift
+++ b/OpenGpxTracker/UIColor+DarkMode.swift
@@ -28,5 +28,29 @@ extension UIColor {
             @unknown default:           return .systemGray
                 }
     }
+
+    static let keyboardColor = UIColor { (traitCollection: UITraitCollection) -> UIColor in
+        switch traitCollection.userInterfaceStyle {
+            case .unspecified, .light:  return .lightKeyboard
+            case .dark:                 return .darkKeyboard
+            @unknown default:           return .lightKeyboard
+                }
+    }
     
+    static let highlightKeyboardColor = UIColor { (traitCollection: UITraitCollection) -> UIColor in
+        switch traitCollection.userInterfaceStyle {
+            case .unspecified, .light:  return .highlightLightKeyboard
+            case .dark:                 return .highlightDarkKeyboard
+            @unknown default:           return .highlightLightKeyboard
+                }
+    }
+    
+}
+
+extension UIColor {
+    static let lightKeyboard = UIColor(red: 209/255, green: 213/255, blue: 219/255, alpha: 1.00)
+    static let darkKeyboard = UIColor(red: 36/255, green: 36/255, blue: 36/255, alpha: 1.00)
+    
+    static let highlightLightKeyboard = UIColor(red: 229/255, green: 233/255, blue: 239/255, alpha: 1.00)
+    static let highlightDarkKeyboard = UIColor(red: 56/255, green: 56/255, blue: 56/255, alpha: 1.00)
 }

--- a/OpenGpxTracker/UIColor+Keyboard.swift
+++ b/OpenGpxTracker/UIColor+Keyboard.swift
@@ -1,0 +1,21 @@
+//
+//  UIColor+Keyboard.swift
+//  OpenGpxTracker
+//
+//  Created by Vincent Neo on 17/4/20.
+//
+
+import UIKit
+
+/// For `DateFieldTypeView`. Meant to match default keyboard colors.
+extension UIColor {
+    /// Default Light Appearance Keyboard
+    static let lightKeyboard = UIColor(red: 209/255, green: 213/255, blue: 219/255, alpha: 1.00)
+    /// Default Dark Appearance Keyboard
+    static let darkKeyboard = UIColor(red: 36/255, green: 36/255, blue: 36/255, alpha: 1.00)
+    
+    /// Button Highlight Light Appearance Keyboard
+    static let highlightLightKeyboard = UIColor(red: 229/255, green: 233/255, blue: 239/255, alpha: 1.00)
+    /// Button Highlight Dark Appearance Keyboard
+    static let highlightDarkKeyboard = UIColor(red: 56/255, green: 56/255, blue: 56/255, alpha: 1.00)
+}

--- a/OpenGpxTracker/UIInsetLabel.swift
+++ b/OpenGpxTracker/UIInsetLabel.swift
@@ -1,0 +1,28 @@
+//
+//  UIInsetLabel.swift
+//  OpenGpxTracker
+//
+//  Created by Vincent Neo on 17/4/20.
+//
+
+import UIKit
+
+/// UILabel that accepts insets padding.
+class UIInsetLabel: UILabel {
+    /// Insert the insets you need here. Defaults to zero.
+    var insets = UIEdgeInsets.zero
+    
+    override func drawText(in rect: CGRect) {
+        super.drawText(in: rect.inset(by: insets))
+    }
+    
+    override var intrinsicContentSize: CGSize {
+        var size = super.intrinsicContentSize
+        
+        size.width += insets.left + insets.right
+        size.height += insets.top + insets.bottom
+
+        return size
+    }
+
+}

--- a/OpenGpxTracker/UIInsetLabel.swift
+++ b/OpenGpxTracker/UIInsetLabel.swift
@@ -12,10 +12,12 @@ class UIInsetLabel: UILabel {
     /// Insert the insets you need here. Defaults to zero.
     var insets = UIEdgeInsets.zero
     
+    ///
     override func drawText(in rect: CGRect) {
         super.drawText(in: rect.inset(by: insets))
     }
     
+    ///
     override var intrinsicContentSize: CGSize {
         var size = super.intrinsicContentSize
         

--- a/OpenGpxTracker/ViewController.swift
+++ b/OpenGpxTracker/ViewController.swift
@@ -838,10 +838,12 @@ class ViewController: UIViewController, UIGestureRecognizerDelegate  {
     /// returns a string with the format of current date dd-MMM-yyyy-HHmm' (20-Jun-2018-1133)
     ///
     func defaultFilename() -> String {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "dd-MMM-yyyy-HHmm"
-        print("fileName:" + dateFormatter.string(from: Date()))
-        return dateFormatter.string(from: Date())
+        let defaultDate = DefaultDateFormat()
+        //let dateFormatter = DateFormatter()
+        //dateFormatter.dateFormat = "dd-MMM-yyyy-HHmm"
+        let dateStr = defaultDate.getDateFromPrefs()
+        print("fileName:" + dateStr)//dateFormatter.string(from: Date()))
+        return dateStr//dateFormatter.string(from: Date())
     }
     
     @objc func loadRecoveredFile(_ notification: Notification) {

--- a/OpenGpxTracker/de.lproj/Localizable.strings
+++ b/OpenGpxTracker/de.lproj/Localizable.strings
@@ -105,3 +105,19 @@
 
 "CONTINUE_SESSION" = "Sitzung fortsetzen";
 "SAVE_START_NEW" = "Speichern und Neustart";
+
+// Default File Name
+
+// in preferences section
+"DEFAULT_NAME_SECTION" = "Default file name setup";
+
+// in default name editor view
+"DEFAULT_NAME_DATE_FORMAT" = "Date Format";
+"DEFAULT_NAME_SETTINGS" = "Settings";
+"DEFAULT_NAME_PRESET" = "Presets";
+
+"DEFAULT_NAME_INPUT_FOOTER" = "Clicking done on the keyboard saves the date format for use, regardless if its a preset or custom. Date format should be encapsulated within { ... }. For full list of applicable date format syntax please refer to Unicode Technical Standard (UTS) #35.";
+
+"DEFAULT_NAME_SAMPLE_OUTPUT_TITLE" = "Sample: ";
+"DEFAULT_NAME_USE_UTC" = "Use UTC Time?";
+"DEFAULT_NAME_ENGLISH_LOCALE" = "Force English language based date formatting?";

--- a/OpenGpxTracker/en.lproj/Localizable.strings
+++ b/OpenGpxTracker/en.lproj/Localizable.strings
@@ -108,3 +108,19 @@
 
 "CONTINUE_SESSION" = "Continue session";
 "SAVE_START_NEW" = "Save and start new";
+
+// Default File Name
+
+// in preferences section
+"DEFAULT_NAME_SECTION" = "Default file name setup";
+
+// in default name editor view
+"DEFAULT_NAME_DATE_FORMAT" = "Date Format";
+"DEFAULT_NAME_SETTINGS" = "Settings";
+"DEFAULT_NAME_PRESET" = "Presets";
+
+"DEFAULT_NAME_INPUT_FOOTER" = "Clicking done on the keyboard saves the date format for use, regardless if its a preset or custom. Date format should be encapsulated within { ... }. For full list of applicable date format syntax please refer to Unicode Technical Standard (UTS) #35.";
+
+"DEFAULT_NAME_SAMPLE_OUTPUT_TITLE" = "Sample: ";
+"DEFAULT_NAME_USE_UTC" = "Use UTC Time?";
+"DEFAULT_NAME_ENGLISH_LOCALE" = "Force English language based date formatting?";

--- a/OpenGpxTracker/en.lproj/Localizable.strings
+++ b/OpenGpxTracker/en.lproj/Localizable.strings
@@ -115,7 +115,7 @@
 "DEFAULT_NAME_SECTION" = "Default file name setup";
 
 // in default name editor view
-"DEFAULT_NAME_DATE_FORMAT" = "Date Format";
+"DEFAULT_NAME_DATE_FORMAT" = "File Name Format";
 "DEFAULT_NAME_SETTINGS" = "Settings";
 "DEFAULT_NAME_PRESET" = "Presets";
 
@@ -124,3 +124,32 @@
 "DEFAULT_NAME_SAMPLE_OUTPUT_TITLE" = "Sample: ";
 "DEFAULT_NAME_USE_UTC" = "Use UTC Time?";
 "DEFAULT_NAME_ENGLISH_LOCALE" = "Force English language based date formatting?";
+
+// DateFieldTypeView
+"YEAR" = "Year";
+"MONTH" = "Month";
+"DAY" = "Day";
+"HOUR" = "Hour";
+"MINUTE" = "Minute";
+"SECOND" = "Second";
+"DAY_OF_THE_WEEK" = "Day of the week";
+"TIME_OF_DAY" = "Time of day";
+"WEEK" = "Week";
+"QUARTER" = "Quarter";
+"ERA" = "Era";
+"TIME_ZONE" = "Time Zone";
+
+"SINGLE_DIGIT" = "Single";
+"FULL_TEXT" = "Full";
+"TEXT" = "Text";
+
+"OF_MONTH" = "Of Month";
+"OF_YEAR" = "Of Year";
+
+"ABBR_GMT" = "Abbr. / GMT";
+"UTC_OFFSET" = "UTC offset";
+"GMT_SHORT" = "GMT short";
+"GMT_FULL" = "GMT full";
+"LOCATION" = "Location";
+"LOCATION_TIME" = "Location's Time";
+

--- a/OpenGpxTracker/es.lproj/Localizable.strings
+++ b/OpenGpxTracker/es.lproj/Localizable.strings
@@ -107,20 +107,48 @@
 "CONTINUE_SESSION_MESSAGE" = "¿Qué quieres hacer con la información recuperada de la última sesión?";
 
 "CONTINUE_SESSION" = "Continuar la sesión";
-"SAVE_START_NEW" = "Guardar y comernzar una nueva";
+"SAVE_START_NEW" = "Guardar y comenzar una nueva";
 
 // Default File Name
 
 // in preferences section
-"DEFAULT_NAME_SECTION" = "Default file name setup";
+"DEFAULT_NAME_SECTION" = "Ajuste de nombre por defecto";
 
 // in default name editor view
-"DEFAULT_NAME_DATE_FORMAT" = "Date Format";
-"DEFAULT_NAME_SETTINGS" = "Settings";
-"DEFAULT_NAME_PRESET" = "Presets";
+"DEFAULT_NAME_DATE_FORMAT" = "Formato de fecha";
+"DEFAULT_NAME_SETTINGS" = "Ajustes";
+"DEFAULT_NAME_PRESET" = "Formatos predefinidos";
 
-"DEFAULT_NAME_INPUT_FOOTER" = "Clicking done on the keyboard saves the date format for use, regardless if its a preset or custom. Date format should be encapsulated within { ... }. For full list of applicable date format syntax please refer to Unicode Technical Standard (UTS) #35.";
+"DEFAULT_NAME_INPUT_FOOTER" = "Al pulsar Aceptar en el teclado se guarda el formato independientemente de si es un formato predefinido o personalizado. Cada elemento de la de fecha debe encapsularse dentro de { ... }";
 
-"DEFAULT_NAME_SAMPLE_OUTPUT_TITLE" = "Sample: ";
-"DEFAULT_NAME_USE_UTC" = "Use UTC Time?";
-"DEFAULT_NAME_ENGLISH_LOCALE" = "Force English language based date formatting?";
+"DEFAULT_NAME_SAMPLE_OUTPUT_TITLE" = "Ejemplo: ";
+"DEFAULT_NAME_USE_UTC" = "¿Usar hora UTC?";
+"DEFAULT_NAME_ENGLISH_LOCALE" = "¿Forzar texto de la fecha en inglés?";
+
+// DateFieldTypeView
+"YEAR" = "Año";
+"MONTH" = "Mes";
+"DAY" = "Día";
+"HOUR" = "Hora";
+"MINUTE" = "Minuto";
+"SECOND" = "Segundo";
+"DAY_OF_THE_WEEK" = "Día de la semana";
+"TIME_OF_DAY" = "Hora del día";
+"WEEK" = "Semana";
+"QUARTER" = "Trimestre";
+"ERA" = "Era";
+"TIME_ZONE" = "Huso horario";
+
+"SINGLE_DIGIT" = "Sencillo";
+"FULL_TEXT" = "Completo";
+"TEXT" = "Texto";
+
+"OF_MONTH" = "Del mes";
+"OF_YEAR" = "Del año";
+
+"ABBR_GMT" = "Abrev. / GMT";
+"UTC_OFFSET" = "Desplazaciento UTC";
+"GMT_SHORT" = "GMT corto";
+"GMT_FULL" = "GMT completo";
+"LOCATION" = "Ubicación";
+"LOCATION_TIME" = "Hora en la ubicación";

--- a/OpenGpxTracker/es.lproj/Localizable.strings
+++ b/OpenGpxTracker/es.lproj/Localizable.strings
@@ -108,3 +108,19 @@
 
 "CONTINUE_SESSION" = "Continuar la sesión";
 "SAVE_START_NEW" = "Guardar y comernzar una nueva";
+
+// Default File Name
+
+// in preferences section
+"DEFAULT_NAME_SECTION" = "Default file name setup";
+
+// in default name editor view
+"DEFAULT_NAME_DATE_FORMAT" = "Date Format";
+"DEFAULT_NAME_SETTINGS" = "Settings";
+"DEFAULT_NAME_PRESET" = "Presets";
+
+"DEFAULT_NAME_INPUT_FOOTER" = "Clicking done on the keyboard saves the date format for use, regardless if its a preset or custom. Date format should be encapsulated within { ... }. For full list of applicable date format syntax please refer to Unicode Technical Standard (UTS) #35.";
+
+"DEFAULT_NAME_SAMPLE_OUTPUT_TITLE" = "Sample: ";
+"DEFAULT_NAME_USE_UTC" = "Use UTC Time?";
+"DEFAULT_NAME_ENGLISH_LOCALE" = "Force English language based date formatting?";

--- a/OpenGpxTracker/uk.lproj/Localizable.strings
+++ b/OpenGpxTracker/uk.lproj/Localizable.strings
@@ -108,3 +108,19 @@
 
 "CONTINUE_SESSION" = "Продовжити сеанс";
 "SAVE_START_NEW" = "Зберегти та розпочати новий";
+
+// Default File Name
+
+// in preferences section
+"DEFAULT_NAME_SECTION" = "Default file name setup";
+
+// in default name editor view
+"DEFAULT_NAME_DATE_FORMAT" = "Date Format";
+"DEFAULT_NAME_SETTINGS" = "Settings";
+"DEFAULT_NAME_PRESET" = "Presets";
+
+"DEFAULT_NAME_INPUT_FOOTER" = "Clicking done on the keyboard saves the date format for use, regardless if its a preset or custom. Date format should be encapsulated within { ... }. For full list of applicable date format syntax please refer to Unicode Technical Standard (UTS) #35.";
+
+"DEFAULT_NAME_SAMPLE_OUTPUT_TITLE" = "Sample: ";
+"DEFAULT_NAME_USE_UTC" = "Use UTC Time?";
+"DEFAULT_NAME_ENGLISH_LOCALE" = "Force English language based date formatting?";

--- a/OpenGpxTracker/zh-Hans.lproj/Localizable.strings
+++ b/OpenGpxTracker/zh-Hans.lproj/Localizable.strings
@@ -112,3 +112,19 @@
 
 "CONTINUE_SESSION" = "继续记录";
 "SAVE_START_NEW" = "储存恢复好的记录，并从新开始";
+
+// Default File Name
+
+// in preferences section
+"DEFAULT_NAME_SECTION" = "预设文件名";
+
+// in default name editor view
+"DEFAULT_NAME_DATE_FORMAT" = "文件名格式（根据日期和时间）";
+"DEFAULT_NAME_SETTINGS" = "设置";
+"DEFAULT_NAME_PRESET" = "预定程序";
+
+"DEFAULT_NAME_INPUT_FOOTER" = "在键盘上，按下 “完成” 按钮，无论预定程序有被更改或新程序，就等于设定了文件名格式。关于日期或时间的句法设定，请使用 { ... } 来包围。全部日期或时间的句法可在 Unicode Technical Standard (UTS) #35 里了解。";
+
+"DEFAULT_NAME_SAMPLE_OUTPUT_TITLE" = "样品：";
+"DEFAULT_NAME_USE_UTC" = "要使用 UTC Time 吗？";
+"DEFAULT_NAME_ENGLISH_LOCALE" = "要使用英文日期和时间写法吗？";

--- a/OpenGpxTracker/zh-Hans.lproj/Localizable.strings
+++ b/OpenGpxTracker/zh-Hans.lproj/Localizable.strings
@@ -126,5 +126,33 @@
 "DEFAULT_NAME_INPUT_FOOTER" = "在键盘上，按下 “完成” 按钮，无论预定程序有被更改或新程序，就等于设定了文件名格式。关于日期或时间的句法设定，请使用 { ... } 来包围。全部日期或时间的句法可在 Unicode Technical Standard (UTS) #35 里了解。";
 
 "DEFAULT_NAME_SAMPLE_OUTPUT_TITLE" = "样品：";
-"DEFAULT_NAME_USE_UTC" = "要使用 UTC Time 吗？";
+"DEFAULT_NAME_USE_UTC" = "要使用 协调世界时（UTC）吗？";
 "DEFAULT_NAME_ENGLISH_LOCALE" = "要使用英文日期和时间写法吗？";
+
+// DateFieldTypeView
+"YEAR" = "年";
+"MONTH" = "月";
+"DAY" = "日";
+"HOUR" = "小时";
+"MINUTE" = "分钟";
+"SECOND" = "秒";
+"DAY_OF_THE_WEEK" = "星期几";
+"TIME_OF_DAY" = "AM/PM";
+"WEEK" = "周";
+"QUARTER" = "季度";
+"ERA" = "时代";
+"TIME_ZONE" = "时区";
+
+"SINGLE_DIGIT" = "单数";
+"FULL_TEXT" = "整体";
+"TEXT" = "全文";
+
+"OF_MONTH" = "月";
+"OF_YEAR" = "年";
+
+"ABBR_GMT" = "简写时区 / GMT";
+"UTC_OFFSET" = "UTC 偏移量";
+"GMT_SHORT" = "GMT 简写";
+"GMT_FULL" = "GMT 整体";
+"LOCATION" = "地点";
+"LOCATION_TIME" = "地点时区";


### PR DESCRIPTION
close #146.

This pull request implements a UI that allows users to choose their own default file name based on their own requirements. I'm hoping that the UI is self explanatory and easy to understand.

Basically date/time syntax is wrapped by `{}`, instead of default date formatter formatting, as I believe that it will be easier for normal users to understand.

Keyboard has a bar with some date/time inputs, but can definitely be improved as it is currently very vague. (But idk what kind of view I should use)

Option to force use of english locale date as filename is also available, for when Locale language is not English. 

Overall it should work well for people that uses one of 5 presets or knows custom date formatting syntax for now in this pull request.