### PR TITLE
Fix location permissions warning issue (closes #193)

### DIFF
--- a/OpenGpxTracker-Watch Extension/InterfaceController.swift
+++ b/OpenGpxTracker-Watch Extension/InterfaceController.swift
@@ -331,14 +331,23 @@ class InterfaceController: WKInterfaceController {
     /// - Seealso: displayLocationServicesDisabledAlert, displayLocationServicesDeniedAlert
     ///
     func checkLocationServicesStatus() {
-        //Are location services enabled?
-        if !CLLocationManager.locationServicesEnabled() {
-            displayLocationServicesDisabledAlert()
+        let authorizationStatus = CLLocationManager.authorizationStatus()
+        
+        //Has the user already made a permission choice?
+        guard authorizationStatus != .notDetermined else {
+            //We should take no action until the user has made a choice
             return
         }
+        
         //Does the app have permissions to use the location servies?
-        if !([.authorizedAlways, .authorizedWhenInUse].contains(CLLocationManager.authorizationStatus())) {
+        guard [.authorizedAlways, .authorizedWhenInUse ].contains(authorizationStatus) else {
             displayLocationServicesDeniedAlert()
+            return
+        }
+        
+        //Are location services enabled?
+        guard CLLocationManager.locationServicesEnabled() else {
+            displayLocationServicesDisabledAlert()
             return
         }
     }


### PR DESCRIPTION
## Summary

Fixed an issue (#193) where a location permissions warning alert controller was presented in all cases for a fresh install of the app.

## Root Cause

The problem was that the app did not check if the location permissions were requested before, so even if the user was never presented with a prompt the warning case would trigger - meaning users would always be shown the permissions denied warning no matter what they chose.

The fix is to rely on the `CLLocationManagerDelegate` call back of `locationManagerDidChangeAuthorization(_ :)`
which is called both at initialization time of `CLLocationManager` and when permissions are changed.
The check at `appDidBecomeActive` time has been removed because the aforementioned delegate call accomplishes the same thing.

See below:
![bug](https://user-images.githubusercontent.com/14207617/101123153-03893180-35a9-11eb-9ff2-4a579a064972.gif)

My first contribution here, please let me know if anything isn't up to snuff :D 
Especially on the watch side of things - I applied the same changes but am not 100% on the CoreLocation APIs there.
