### PR TITLE
Fix for glitchy polylines

### DIFF
--- a/OpenGpxTracker/MapViewDelegate.swift
+++ b/OpenGpxTracker/MapViewDelegate.swift
@@ -50,7 +50,12 @@ class MapViewDelegate: NSObject, MKMapViewDelegate, UIAlertViewDelegate {
             pr.strokeColor = UIColor.blue
             
             if #available(iOS 13, *) {
-                pr.shouldRasterize = false
+                if #available(iOS 14, *) {
+                    pr.shouldRasterize = false
+                }
+                else {
+                    pr.shouldRasterize = true
+                }
                 if mapView.traitCollection.userInterfaceStyle == .dark {
                     pr.alpha = 0.5
                     pr.strokeColor = UIColor.yellow

--- a/OpenGpxTracker/MapViewDelegate.swift
+++ b/OpenGpxTracker/MapViewDelegate.swift
@@ -50,7 +50,7 @@ class MapViewDelegate: NSObject, MKMapViewDelegate, UIAlertViewDelegate {
             pr.strokeColor = UIColor.blue
             
             if #available(iOS 13, *) {
-                pr.shouldRasterize = true
+                pr.shouldRasterize = false
                 if mapView.traitCollection.userInterfaceStyle == .dark {
                     pr.alpha = 0.5
                     pr.strokeColor = UIColor.yellow


### PR DESCRIPTION
For #199. Tested to solve the iOS 14.5 glitching issues.

Might be able to close too, since I believe the crash issue has to do with other things about the app instead of the poly line.

Note: this pr will merge to `projectRefresh2021` branch.