### PR TITLE
Added new option for selecting custom output folder

### DIFF
--- a/OpenGpxTracker/GPXFileManager.swift
+++ b/OpenGpxTracker/GPXFileManager.swift
@@ -36,7 +36,9 @@ class GPXFileManager: NSObject {
         let documentsURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
         var files = self.fetchFilesList(from: documentsURL)
         if let customFolderURL = Preferences.shared.gpxFilesFolderURL {
+            _ = customFolderURL.startAccessingSecurityScopedResource()
             files += self.fetchFilesList(from: customFolderURL)
+            customFolderURL.stopAccessingSecurityScopedResource()
         }
         return files.sorted { lhs, rhs in
             return lhs.modifiedDate > rhs.modifiedDate

--- a/OpenGpxTracker/GPXFileManager.swift
+++ b/OpenGpxTracker/GPXFileManager.swift
@@ -21,7 +21,10 @@ class GPXFileManager: NSObject {
     /// Folder that where all GPX files are stored
     ///
     class var GPXFilesFolderURL: URL {
-        let documentsUrl =  FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0] as URL
+        if let customFolderURL = Preferences.shared.gpxFilesFolderURL {
+            return customFolderURL
+        }
+        let documentsUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0] as URL
         return documentsUrl
     }
     
@@ -29,36 +32,15 @@ class GPXFileManager: NSObject {
     /// Gets the list of `.gpx` files in Documents directory ordered by modified date
     ///
     class var fileList: [GPXFileInfo] {
-        var GPXFiles: [GPXFileInfo] = []
         let fileManager = FileManager.default
         let documentsURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
-        do {
-            // Get all files from the directory .documentsURL. Of each file get the URL (~path)
-            // last modification date and file size
-            if let directoryURLs = try? fileManager.contentsOfDirectory(at: documentsURL,
-                includingPropertiesForKeys: [.attributeModificationDateKey, .fileSizeKey],
-                options: .skipsSubdirectoryDescendants) {
-                //Order files based on the date
-                // This map creates a tuple (url: URL, modificationDate: String, filesize: Int)
-                // and then orders it by modificationDate
-                let sortedURLs = directoryURLs.map { url in
-                    (url: url,
-                     modificationDate: (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? Date.distantPast,
-                     fileSize: (try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0)
-                    }
-                    .sorted(by: { $0.1 > $1.1 }) // sort descending modification dates
-                print(sortedURLs)
-                //Now we filter GPX Files
-                for (url, modificationDate, fileSize) in sortedURLs {
-                    if kFileExt.contains(url.pathExtension) {
-                        GPXFiles.append(GPXFileInfo(fileURL: url))
-                        let lastPathComponent = url.deletingPathExtension().lastPathComponent
-                        print("\(modificationDate) \(modificationDate.timeAgo(numericDates: true)) \(fileSize)bytes -- \(lastPathComponent)")
-                    }
-                }
-            }
+        var files = self.fetchFilesList(from: documentsURL)
+        if let customFolderURL = Preferences.shared.gpxFilesFolderURL {
+            files += self.fetchFilesList(from: customFolderURL)
         }
-        return GPXFiles
+        return files.sorted { lhs, rhs in
+            return lhs.modifiedDate > rhs.modifiedDate
+        }
     }
     
     ///
@@ -198,5 +180,39 @@ class GPXFileManager: NSObject {
         } catch {
             print(error)
         }
+    }
+    
+    // MARK: - Private
+    
+    private class func fetchFilesList(from rootURL: URL) -> [GPXFileInfo] {
+        var GPXFiles: [GPXFileInfo] = []
+        let fileManager = FileManager.default
+        do {
+            // Get all files from the directory .documentsURL. Of each file get the URL (~path)
+            // last modification date and file size
+            if let directoryURLs = try? fileManager.contentsOfDirectory(at: rootURL,
+                includingPropertiesForKeys: [.attributeModificationDateKey, .fileSizeKey],
+                options: .skipsSubdirectoryDescendants) {
+                //Order files based on the date
+                // This map creates a tuple (url: URL, modificationDate: String, filesize: Int)
+                // and then orders it by modificationDate
+                let sortedURLs = directoryURLs.map { url in
+                    (url: url,
+                     modificationDate: (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? Date.distantPast,
+                     fileSize: (try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0)
+                    }
+                    .sorted(by: { $0.1 > $1.1 }) // sort descending modification dates
+                print(sortedURLs)
+                //Now we filter GPX Files
+                for (url, modificationDate, fileSize) in sortedURLs {
+                    if kFileExt.contains(url.pathExtension) {
+                        GPXFiles.append(GPXFileInfo(fileURL: url))
+                        let lastPathComponent = url.deletingPathExtension().lastPathComponent
+                        print("\(modificationDate) \(modificationDate.timeAgo(numericDates: true)) \(fileSize)bytes -- \(lastPathComponent)")
+                    }
+                }
+            }
+        }
+        return GPXFiles
     }
 }

--- a/OpenGpxTracker/Preferences.swift
+++ b/OpenGpxTracker/Preferences.swift
@@ -302,6 +302,10 @@ class Preferences: NSObject {
                 var isStale: Bool = false
                 let url = try URL(resolvingBookmarkData: bookmarkData, bookmarkDataIsStale: &isStale)
                 if isStale {
+                    _ = url.startAccessingSecurityScopedResource()
+                    defer {
+                        url.stopAccessingSecurityScopedResource()
+                    }
                     let newBookmark = try url.bookmarkData()
                     _gpxFilesFolderBookmark = newBookmark
                     defaults.set(newBookmark, forKey: kDefaultsKeyGPXFilesFolder)
@@ -318,6 +322,10 @@ class Preferences: NSObject {
                 return
             }
             do {
+                _ = newValue.startAccessingSecurityScopedResource()
+                defer {
+                    newValue.stopAccessingSecurityScopedResource()
+                }
                 let newBookmark = try newValue.bookmarkData()
                 _gpxFilesFolderBookmark = newBookmark
                 defaults.set(newBookmark, forKey: kDefaultsKeyGPXFilesFolder)

--- a/OpenGpxTracker/Preferences.swift
+++ b/OpenGpxTracker/Preferences.swift
@@ -37,6 +37,9 @@ let kDefaultsKeyDateFormatUseUTC: String = "DateFormatPresetUseUTC"
 /// Key on Defaults for the current selected date format, to use local Locale or `en_US_POSIX`
 let kDefaultsKeyDateFormatUseEN: String = "DateFormatPresetUseEN"
 
+/// Key on Defaults for the folder where GPX files are store, `nil` means default folder
+let kDefaultsKeyGPXFilesFolder: String = "GPXFilesFolder"
+
 /// A class to handle app preferences in one single place.
 /// When the app starts for the first time the following preferences are set:
 ///
@@ -79,6 +82,9 @@ class Preferences: NSObject {
     
     ///
     private var _dateFormatUseEN: Bool = false
+    
+    ///
+    private var _gpxFilesFolderBookmark: Data? = nil
     
     /// UserDefaults.standard shortcut
     private let defaults = UserDefaults.standard
@@ -147,6 +153,12 @@ class Preferences: NSObject {
         if let dateFormatENBool = defaults.object(forKey: kDefaultsKeyDateFormatUseEN) as? Bool {
             _dateFormatUseEN = dateFormatENBool
             print("** Preferences:: loaded preference from defaults dateFormatPresetENBool \(dateFormatENBool)")
+        }
+        
+        // load previous gpx files folder bookmark
+        if let gpxFilesFolderBookmark = defaults.object(forKey: kDefaultsKeyGPXFilesFolder) as? Data {
+            _gpxFilesFolderBookmark = gpxFilesFolderBookmark
+            print("** Preferences:: loaded preference from defaults gpxFilesFolderBookmark \(gpxFilesFolderBookmark)")
         }
     }
     
@@ -278,6 +290,40 @@ class Preferences: NSObject {
         set {
             _dateFormatUseEN = newValue
              defaults.set(newValue, forKey: kDefaultsKeyDateFormatUseEN)
+        }
+    }
+    
+    var gpxFilesFolderURL: URL? {
+        get {
+            guard let bookmarkData = self._gpxFilesFolderBookmark else {
+                return nil
+            }
+            do {
+                var isStale: Bool = false
+                let url = try URL(resolvingBookmarkData: bookmarkData, bookmarkDataIsStale: &isStale)
+                if isStale {
+                    let newBookmark = try url.bookmarkData()
+                    _gpxFilesFolderBookmark = newBookmark
+                    defaults.set(newBookmark, forKey: kDefaultsKeyGPXFilesFolder)
+                }
+                return url
+            } catch {
+                print("** Preferences:: failed to retrieve url from bookmark data: \(String(describing: error))")
+                return nil
+            }
+        }
+        set {
+            guard let newValue else {
+                defaults.removeObject(forKey: kDefaultsKeyGPXFilesFolder)
+                return
+            }
+            do {
+                let newBookmark = try newValue.bookmarkData()
+                _gpxFilesFolderBookmark = newBookmark
+                defaults.set(newBookmark, forKey: kDefaultsKeyGPXFilesFolder)
+            } catch {
+                print("** Preferences:: failed to generate bookmark data for url: \(String(describing: error))")
+            }
         }
     }
 }

--- a/OpenGpxTracker/en.lproj/Localizable.strings
+++ b/OpenGpxTracker/en.lproj/Localizable.strings
@@ -44,6 +44,9 @@
 "CACHE_IS_EMPTY" = "Cache is now empty";
 "EDIT_WAYPOINT_NAME_TITLE" = "Edit waypoint name";
 "EDIT_WAYPOINT_NAME_MESSAGE" = "Hint: To change the waypoint location drag and drop the pin";
+"GPX_FILES_LOCATION_SECTION" = "GPX files location";
+"PRESS_TO_SELECT_FOLDER" = "Press to select folder";
+"USING_DEFAULT_FOLDER" = "Using default folder";
 
 // Watch
 "SENDING" = "Sending:";

--- a/OpenGpxTracker/ru.lproj/Localizable.strings
+++ b/OpenGpxTracker/ru.lproj/Localizable.strings
@@ -44,6 +44,9 @@
 "CACHE_IS_EMPTY" = "Кэш очищен";
 "EDIT_WAYPOINT_NAME_TITLE" = "Введите имя метки";
 "EDIT_WAYPOINT_NAME_MESSAGE" = "Подсказка: Чтобы изменить положение метки на карте, перетащите ее";
+"GPX_FILES_LOCATION_SECTION" = "Расположение GPX файлов";
+"PRESS_TO_SELECT_FOLDER" = "Нажмите, чтобы выбрать";
+"USING_DEFAULT_FOLDER" = "Исп. папка по-умолчанию";
 
 // Watch
 "SENDING" = "Отправка:";


### PR DESCRIPTION
Hi!

I added an option for selecting custom output directory for gpx files. This can be local folder on your device or from a cloud service. Potentially, it should resolve #149.

![Simulator Screen Shot - iPhone 14 Pro - 2023-01-02 at 22 12 30](https://user-images.githubusercontent.com/3374306/210281334-6c82fcba-85d9-4ca2-b34b-47177eb17b5c.png)

I added translations for new labels only for English and Russian languages. @merlos what's the approach with other locales? Should I use Google Translate/Deepl or there is a different process?