### PR TITLE
Added OpenSeaMap tile server

### DIFF
--- a/OpenGpxTracker/GPXMapView.swift
+++ b/OpenGpxTracker/GPXMapView.swift
@@ -91,7 +91,8 @@ class GPXMapView: MKMapView {
                 let cache = MapCache(withConfig: config)
                 // the overlay returned substitutes Apple Maps tile overlay.
                 // we need to keep a reference to remove it, in case we return back to Apple Maps.
-                tileServerOverlay = useCache(cache)
+                //
+                tileServerOverlay = useCache(cache, canReplaceMapContent: newValue.canReplaceMapContent)
             }
             else {
                 self.mapType = (newValue == .apple) ? .standard : .satellite

--- a/OpenGpxTracker/GPXTileServer.swift
+++ b/OpenGpxTracker/GPXTileServer.swift
@@ -38,6 +38,9 @@ enum GPXTileServer: Int {
     /// OpenTopoMap tile server
     case openTopoMap
     
+    /// OpenSeaMap tile server
+    case openSeaMap
+    
     ///String that describes the selected tile server.
     var name: String {
         switch self {
@@ -47,6 +50,7 @@ enum GPXTileServer: Int {
         case .cartoDB: return "Carto DB"
         case .cartoDBRetina: return "Carto DB (Retina resolution)"
         case .openTopoMap: return "OpenTopoMap"
+        case .openSeaMap: return "OpenSeaMap"
         }
     }
     
@@ -59,6 +63,7 @@ enum GPXTileServer: Int {
         case .cartoDB: return "https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png"
         case .cartoDBRetina: return "https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}@2x.png"
         case .openTopoMap: return "https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png"
+        case .openSeaMap: return "https://tiles.openseamap.org/seamark/{z}/{x}/{y}.png"
         }
     }
     
@@ -76,6 +81,7 @@ enum GPXTileServer: Int {
         case .openStreetMap: return ["a", "b", "c"]
         case .cartoDB, .cartoDBRetina: return ["a", "b", "c"]
         case .openTopoMap: return ["a", "b", "c"]
+        case .openSeaMap: return []
         // case .AnotherMap: return ["a","b"]
         }
     }
@@ -103,6 +109,8 @@ enum GPXTileServer: Int {
         case .openTopoMap:
             return 17
         // case .AnotherMap: return 10
+        case .openSeaMap:
+            return 16
         }
     }
     ///
@@ -125,7 +133,18 @@ enum GPXTileServer: Int {
             return 0
         case .openTopoMap:
             return 0
-        // case .AnotherMap: return ["a","b"]
+        case .openSeaMap:
+            return 0
+        // case .AnotherMap: return 0
+        }
+    }
+    
+    /// Does the tile overlay replace the map?
+    ///  Generally all the tiles provided replace the AppleMaps. However there are some
+    var canReplaceMapContent: Bool {
+        switch self {
+        case .openSeaMap: return false
+        default: return true
         }
     }
     
@@ -145,5 +164,5 @@ enum GPXTileServer: Int {
     }
 
     /// Returns the number of tile servers currently defined
-    static var count: Int { return GPXTileServer.openTopoMap.rawValue + 1}
+    static var count: Int { return GPXTileServer.openSeaMap.rawValue + 1}
 }


### PR DESCRIPTION
Adds OpenSeaMap tile server.
The tiles have a transparent background, so it was used the  `Mkview+MapCache.userCache(_, canReplaceMapContent)` functionality of added in https://github.com/merlos/MapCache/pull/43

Closes #187 