### PR TITLE
Fix typos in "OpenStreetMap"

### DIFF
--- a/OpenGpxTracker/GPXTileServer.swift
+++ b/OpenGpxTracker/GPXTileServer.swift
@@ -25,7 +25,7 @@ enum GPXTileServer: Int {
     /// Apple satellite tile server
     case appleSatellite
     
-    /// Open Street Map tile server
+    /// OpenStreetMap tile server
     case openStreetMap
     // case AnotherMap
     
@@ -46,7 +46,7 @@ enum GPXTileServer: Int {
         switch self {
         case .apple: return "Apple Mapkit (no offline cache)"
         case .appleSatellite: return "Apple Satellite (no offline cache)"
-        case .openStreetMap: return "Open Street Map"
+        case .openStreetMap: return "OpenStreetMap"
         case .cartoDB: return "Carto DB"
         case .cartoDBRetina: return "Carto DB (Retina resolution)"
         case .openTopoMap: return "OpenTopoMap"

--- a/OpenGpxTracker/about.html
+++ b/OpenGpxTracker/about.html
@@ -82,7 +82,7 @@
    
    <h4>&amp; Vincent Neo <a href="https://www.twitter.com/iVincentNeo">@vincentneo</a></h4>
     
-    <p>Created to help <a href="http://openstreetmap.org">Open Street Map</a> contributors to generate
+    <p>Created to help <a href="http://openstreetmap.org">OpenStreetMap</a> contributors to generate
     <a href="https://www.openstreetmap.org/traces">Public GPX traces</a> and as a tool for developers to create real GPX files to test their apps.</p>
     
     <p>Open GPX Tracker is an open source application distributed under GPL license. The source code is available on <a href="https://github.com/merlos/iOS-Open-GPX-Tracker">GitHub</a></p>
@@ -135,4 +135,3 @@ information about these providers:</p>
 </ul>
 </body>
 </html>
-

--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ Requires iOS 11.0 or above. Open GPX tracker is an open source app.
 
 You can use Open GPX tracker for:
 
- - Creating routes and waypoints for editing Open Street Map.
- - Publishing Open Street Map Traces.
+ - Creating routes and waypoints for editing OpenStreetMap.
+ - Publishing OpenStreetMap Traces.
  - [Creating GPX files for testing your iOS apps in Xcode](https://medium.com/@merlos/how-to-simulate-locations-in-xcode-b0f7f16e126d).
  - Use it as GPS companion when you take pictures with your reflex camera.
 
 ## Main Features
 
  - Displays tracking route in a map
- - Supports Apple Map Kit, [Open Street Map](http://wiki.openstreetmap.org/wiki/Tile_usage_policy), and [Carto DB](http://www.cartodb.com) as map sources
+ - Supports Apple Map Kit, [OpenStreetMap](http://wiki.openstreetmap.org/wiki/Tile_usage_policy), and [Carto DB](http://www.cartodb.com) as map sources
  - Offline maps support (of browsed areas)
  - Pause / Resume tracking
  - Add waypoint to user location
@@ -79,12 +79,12 @@ Then, to test it open the file `OpenGpxTracker.xcworkspace` with XCode.
 
 Although the application uses some Cocoapods, all the pods are already included in our repo. So no need to run `pod install`.
 
-Please note the [limitations of using Open Street Maps Tile Servers](http://wiki.openstreetmap.org/wiki/Tile_usage_policy)
+Please note the [limitations of using OpenStreetMap Tile Servers](http://wiki.openstreetmap.org/wiki/Tile_usage_policy)
 
 ### Add a custom tile server
 Adding a tile server is easy, just edit the file `GPXTileServer.swift`, uncomment the lines with `AnotherMap` and modify the templateUrl to point to the new tile server.
 
-You have a list of tile servers in [Open Street Map Wiki](http://wiki.openstreetmap.org/wiki/Tile_servers)
+You have a list of tile servers in [OpenStreetMap Wiki](http://wiki.openstreetmap.org/wiki/Tile_servers)
 
 ## Reference documentation
 
@@ -157,7 +157,7 @@ Please note that this source code was released under the GPL license.  So any ch
 This app uses:
 - [CoreGPX Framework](https://github.com/vincentneo/CoreGPX), a SWIFT library for using GPX files. Created by [@vincentneo](http://github.com/vincentneo)
 
-Entry on the [Open Street Maps Wiki](https://wiki.openstreetmap.org/wiki/OpenGpxTracker)
+Entry on the [OpenStreetMap Wiki](https://wiki.openstreetmap.org/wiki/OpenGpxTracker)
 
 See also:
 - [Avenue GPX Viewer](https://github.com/vincentneo/Avenue-GPX-Viewer), a GPX viewer based on some of the codes used in this project. A side project by collaborator [@vincentneo](http://github.com/vincentneo).


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix


**What is the current behavior?** (You can also link to an open issue here)
OpenStreetMap is written inconsistently across the code base:
1. "OpenStreetMap" (correct)
2. "OpenStreetMaps"
3. Open Street Map
4. Open Street Maps


**What is the new behavior (if this is a feature change)?**
Incorrect versions changed to "OpenStreetMap".


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
* See the official home page for the correct wording: https://www.openstreetmap.org/.
* There are more occurrences of the typo in the dependency https://github.com/merlos/MapCache which I did not fix.